### PR TITLE
Update signing config default

### DIFF
--- a/Source/AwsCommonRuntimeKit/auth/signing/SigningConfig.swift
+++ b/Source/AwsCommonRuntimeKit/auth/signing/SigningConfig.swift
@@ -26,7 +26,7 @@ public struct SigningConfig {
                 service: String,
                 region: String,
                 expiration: Int64 = 0,
-                signedBodyHeader: SignedBodyHeaderType = .contentSha256,
+                signedBodyHeader: SignedBodyHeaderType = .none,
                 signedBodyValue: SignedBodyValue = SignedBodyValue.empty,
                 flags: Flags = Flags(),
                 shouldSignHeader: ShouldSignHeader? = nil,


### PR DESCRIPTION
*Description of changes:* This PR updates the signing config to have the correct default value for the SignedBodyHeader to be `.none`.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
