### PR TITLE
fix: correct should sign header pointer being nil

### DIFF
--- a/Source/AwsCommonRuntimeKit/auth/signing/SigningConfig.swift
+++ b/Source/AwsCommonRuntimeKit/auth/signing/SigningConfig.swift
@@ -58,24 +58,22 @@ public struct SigningConfig {
                                                service: service.awsByteCursor,
                                                date: date.rawValue.pointee,
                                                should_sign_header: { (name, userData) -> Bool in
-
+                                                
                                                 guard let userData = userData,
-                                                    let name = name?.pointee.toString() else {
+                                                      let name = name?.pointee.toString() else {
                                                     return false
                                                 }
-
+                                                
                                                 let callback = userData.bindMemory(to: ShouldSignHeader?.self,
                                                                                    capacity: 1)
-
+                                                
                                                 if let callbackFn = callback.pointee {
-                                                    defer {
-                                                        callback.deinitializeAndDeallocate()
-                                                    }
+                                                    
                                                     return callbackFn(name)
                                                 } else {
                                                     return true
                                                 }
-                                                },
+                                               },
                                                should_sign_header_ud: pointer,
                                                flags: flags.rawValue,
                                                signed_body_value: signedBodyValue.rawValue.awsByteCursor,


### PR DESCRIPTION
*Description of changes:* This PR fixes a bug where the should sign header function is not nil and thus the pointer to it should not be nil.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
