### PR TITLE
fix: add codable conformance to byte buffer plus extension

### DIFF
--- a/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
@@ -177,6 +177,10 @@ public class ByteBuffer {
         return currentEndianness == .little ? Double(bitPattern: result.littleEndian)
             : Double(bitPattern: result.bigEndian)
     }
+    
+    public func toByteArray() -> [UInt8] {
+        return array
+    }
 
     public enum Endianness {
         case little

--- a/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
@@ -49,11 +49,7 @@ public class ByteBuffer: Codable {
         return self
     }
 
-    public func put(_ value: ByteBuffer) {
-        array.append(contentsOf: value.array)
-    }
-
-    public func put(_ value: ByteBuffer, offset: UInt = 0, maxBytes: UInt?) {
+    public func put(_ value: ByteBuffer, offset: UInt = 0, maxBytes: UInt? = nil) {
         var end: UInt = UInt(value.length)
         if let maxBytes = maxBytes {
              end =  maxBytes

--- a/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
@@ -48,11 +48,11 @@ public class ByteBuffer: Codable {
         array.append(value)
         return self
     }
-    
+
     public func put(_ value: ByteBuffer) {
         array.append(contentsOf: value.array)
     }
-    
+
     public func put(_ value: ByteBuffer, offset: UInt = 0, maxBytes: UInt?) {
         var end: UInt = UInt(value.length)
         if let maxBytes = maxBytes {

--- a/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
@@ -15,7 +15,7 @@ import AwsCIo
  #endif
 
 //swiftlint:disable identifier_name superfluous_disable_command
-public class ByteBuffer {
+public class ByteBuffer: Codable {
 
     public init(size: Int) {
         array.reserveCapacity(size)
@@ -205,6 +205,16 @@ public class ByteBuffer {
     private var hostEndianness: Endianness {
         let number: UInt32 = 0x12345678
         return number == number.bigEndian ? .big : .little
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(array)
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        array = try container.decode([UInt8].self)
     }
 }
 

--- a/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
@@ -232,17 +232,17 @@ extension ByteBuffer: AwsStream {
         return aws_stream_status(is_end_of_stream: self.currentIndex == array.count, is_valid: true)
     }
 
-    public var length: Int64 {
-        return Int64(array.count)
+    public var length: UInt {
+        return UInt(array.count)
     }
 
     public func seek(offset: Int64, basis: aws_stream_seek_basis) -> Bool {
         let targetOffset: Int64
         if basis.rawValue == AWS_SSB_BEGIN.rawValue {
-            targetOffset = length + offset
+            targetOffset = Int64(length) + offset
 
         } else {
-            targetOffset = length - offset
+            targetOffset = Int64(length) - offset
         }
         currentIndex = Int(targetOffset)
         return true

--- a/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
@@ -177,7 +177,7 @@ public class ByteBuffer: Codable {
         return currentEndianness == .little ? Double(bitPattern: result.littleEndian)
             : Double(bitPattern: result.bigEndian)
     }
-    
+
     public func toByteArray() -> [UInt8] {
         return array
     }
@@ -206,12 +206,12 @@ public class ByteBuffer: Codable {
         let number: UInt32 = 0x12345678
         return number == number.bigEndian ? .big : .little
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(array)
     }
-    
+
     public required init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         array = try container.decode([UInt8].self)

--- a/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
@@ -48,6 +48,19 @@ public class ByteBuffer: Codable {
         array.append(value)
         return self
     }
+    
+    public func put(_ value: ByteBuffer) {
+        array.append(contentsOf: value.array)
+    }
+    
+    public func put(_ value: ByteBuffer, offset: UInt = 0, maxBytes: UInt?) {
+        var end: UInt = UInt(value.length)
+        if let maxBytes = maxBytes {
+             end =  maxBytes
+        }
+        let bytesToTake = value.array[Int(offset)..<Int(end)]
+        array.append(contentsOf: bytesToTake)
+    }
 
     public func put(_ value: Data) {
         let byteArray: [UInt8] = value.map { $0 }

--- a/Source/AwsCommonRuntimeKit/io/Stream.swift
+++ b/Source/AwsCommonRuntimeKit/io/Stream.swift
@@ -16,7 +16,7 @@ public class AwsInputStream {
     public var length: Int64
 
     public init(_ impl: AwsStream, allocator: Allocator = defaultAllocator) {
-        self.length = impl.length
+        self.length = Int64(impl.length)
         let ptr = UnsafeMutablePointer<AwsStream>.allocate(capacity: 1)
         ptr.initialize(to: impl)
         self.implPointer = ptr
@@ -30,7 +30,7 @@ public class AwsInputStream {
 
 public protocol AwsStream {
     var status: aws_stream_status { get }
-    var length: Int64 { get }
+    var length: UInt { get }
 
     func seek(offset: Int64, basis: aws_stream_seek_basis) -> Bool
     func read(buffer: inout aws_byte_buf) -> Bool
@@ -43,11 +43,11 @@ extension FileHandle: AwsStream {
     }
 
     @inlinable
-    public var length: Int64 {
+    public var length: UInt {
         let savedPos = self.offsetInFile
         defer { self.seek(toFileOffset: savedPos ) }
         self.seekToEndOfFile()
-        return Int64(self.offsetInFile)
+        return UInt(self.offsetInFile)
     }
 
     @inlinable
@@ -106,7 +106,7 @@ private func doGetLength(_ stream: UnsafeMutablePointer<aws_input_stream>!,
     let inputStream = stream.pointee.impl.bindMemory(to: AwsStream.self, capacity: 1).pointee
     let length = inputStream.length
     if length >= 0 {
-        result.pointee = length
+        result.pointee = Int64(length)
         return AWS_OP_SUCCESS
     }
     aws_raise_error(Int32(AWS_IO_STREAM_READ_FAILED.rawValue))


### PR DESCRIPTION
*Description of changes:* This PR adds needed extensions to use `ByteBuffer` in streaming in the sdk


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
