### PR TITLE
fix:  bug where you have to pass all three params to use profile cred provider

### DIFF
--- a/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
@@ -76,11 +76,15 @@ public final class CRTAWSCredentialsProvider {
                             allocator: Allocator = defaultAllocator) throws {
 
         var profileOptionsC = aws_credentials_provider_profile_options()
-        if let configFileName = profileOptions.configFileNameOverride,
-           let credentialsFileName = profileOptions.credentialsFileNameOverride,
-           let profileName = profileOptions.profileFileNameOverride {
+        if let configFileName = profileOptions.configFileNameOverride {
             profileOptionsC.config_file_name_override = configFileName.awsByteCursor
+        }
+        
+        if let credentialsFileName = profileOptions.credentialsFileNameOverride {
             profileOptionsC.credentials_file_name_override = credentialsFileName.awsByteCursor
+        }
+        
+        if let profileName = profileOptions.profileFileNameOverride {
             profileOptionsC.profile_name_override = profileName.awsByteCursor
         }
         profileOptionsC.shutdown_options = WrappedCRTCredentialsProvider.setUpShutDownOptions(

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
@@ -79,11 +79,11 @@ public final class CRTAWSCredentialsProvider {
         if let configFileName = profileOptions.configFileNameOverride {
             profileOptionsC.config_file_name_override = configFileName.awsByteCursor
         }
-        
+
         if let credentialsFileName = profileOptions.credentialsFileNameOverride {
             profileOptionsC.credentials_file_name_override = credentialsFileName.awsByteCursor
         }
-        
+
         if let profileName = profileOptions.profileFileNameOverride {
             profileOptionsC.profile_name_override = profileName.awsByteCursor
         }


### PR DESCRIPTION
*Description of changes:* Correct issue where in order to get a profile cred provider, you were forced to pass in the names of your config and cred files even if it was the default ones.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
