### PR TITLE
fix: static credetnials provider

### DIFF
--- a/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
@@ -37,7 +37,9 @@ public final class CRTAWSCredentialsProvider {
             shutDownOptions: config.shutDownOptions)
         staticOptions.access_key_id = config.accessKey.awsByteCursor
         staticOptions.secret_access_key = config.secret.awsByteCursor
-        staticOptions.session_token = config.sessionToken.awsByteCursor
+        if let sessionToken = config.sessionToken?.awsByteCursor {
+            staticOptions.session_token = sessionToken
+        }
 
         guard let provider = aws_credentials_provider_new_static(allocator.rawValue,
                                                                  &staticOptions) else { throw AWSCommonRuntimeError() }

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CRTCredentialsProviderStaticConfig.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CRTCredentialsProviderStaticConfig.swift
@@ -4,6 +4,6 @@
 public protocol CRTCredentialsProviderStaticConfigOptions {
     var accessKey: String { get set}
     var secret: String { get set}
-    var sessionToken: String { get set}
+    var sessionToken: String? { get set}
     var shutDownOptions: CRTCredentialsProviderShutdownOptions? { get set}
 }

--- a/Test/AwsCommonRuntimeKitTests/auth/AWSCredentialsProviderTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/auth/AWSCredentialsProviderTests.swift
@@ -173,12 +173,12 @@ struct MockCredentialsProviderProfileOptions: CRTCredentialsProviderProfileOptio
 struct MockCredentialsProviderStaticConfigOptions: CRTCredentialsProviderStaticConfigOptions {
     public var accessKey: String
     public var secret: String
-    public var sessionToken: String
+    public var sessionToken: String?
     public var shutDownOptions: CRTCredentialsProviderShutdownOptions?
     
     public init(accessKey: String,
                 secret: String,
-                sessionToken: String,
+                sessionToken: String? = nil,
                 shutDownOptions: CRTCredentialsProviderShutdownOptions? = nil) {
         self.accessKey = accessKey
         self.secret = secret


### PR DESCRIPTION
*Description of changes:* Session token should be optional to pass. correct behavior for static credentials provider


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
