### PR TITLE
fix: refactor pointer creation to protect against improper init

### DIFF
--- a/Source/AwsCommonRuntimeKit/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/Utilities.swift
@@ -58,11 +58,18 @@ extension Bool {
     }
 }
 
-func fromPointer<T, P: PointerConformance>(ptr: T?) -> P? {
-   if let ptr = ptr {
-        let pointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
-        pointer.initialize(to: ptr)
-       return P(OpaquePointer(pointer))
+// Ensure that any UnsafeXXXPointer is ALWAYS initialized to either nil or a value in a single call. Prevents the
+// case where you create an UnsafeMutableWhatever and do not call `initialize()` on it, resulting in a non-null but
+// also invalid pointer
+func fromPointer<T, P: PointerConformance>(ptr: T) -> P {
+    let pointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
+    pointer.initialize(to: ptr)
+    return P(OpaquePointer(pointer))
+}
+
+func fromOptionalPointer<T, P: PointerConformance>(ptr: T?) -> P? {
+    if let ptr = ptr {
+        return fromPointer(ptr: ptr)
     }
     return nil
 }

--- a/Source/AwsCommonRuntimeKit/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/Utilities.swift
@@ -74,6 +74,21 @@ func fromOptionalPointer<T, P: PointerConformance>(ptr: T?) -> P? {
     return nil
 }
 
+func allocate<T>(_ capacity: Int = 1) -> UnsafeMutablePointer<T> {
+    let ptr = UnsafeMutablePointer<T>.allocate(capacity: capacity)
+    zeroStruct(ptr)
+    return ptr
+}
+
+func toPointerArray<T, P: PointerConformance>(_ array: [T]) -> P {
+    let pointers = UnsafeMutablePointer<T>.allocate(capacity: array.count)
+
+    for index in 0...array.count {
+        pointers.advanced(by: index).initialize(to: array[index])
+    }
+    return P(OpaquePointer(pointers))
+}
+
 protocol PointerConformance {
     init(_ pointer: OpaquePointer)
 }

--- a/Source/AwsCommonRuntimeKit/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/Utilities.swift
@@ -58,24 +58,43 @@ extension Bool {
     }
 }
 
-func getMutablePointer<T>(memoryType: T?) -> UnsafeMutablePointer<T>? {
-    if let memoryType = memoryType {
+func fromPointer<T, P: PointerConformance>(ptr: T?) -> P? {
+   if let ptr = ptr {
         let pointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
-        pointer.initialize(to: memoryType)
-        return pointer
+        pointer.initialize(to: ptr)
+       return P(pointer: OpaquePointer(pointer))
     }
-
     return nil
 }
 
-func getMutableRawPointer<T>(memoryType: T?) -> UnsafeMutableRawPointer? {
-    return UnsafeMutableRawPointer(getMutablePointer(memoryType: memoryType))
+protocol PointerConformance {
+
+    init(pointer: OpaquePointer)
 }
 
-func getUnsafePointer<T>(memoryType: T?) -> UnsafePointer<T>? {
-    return UnsafePointer(getMutablePointer(memoryType: memoryType))
+extension UnsafeMutablePointer: PointerConformance {
+    init(pointer: OpaquePointer) {
+        self = UnsafeMutablePointer(pointer)
+    }
 }
 
-func getUnsafeRawPointer<T>(memoryType: T?) -> UnsafeRawPointer? {
-    return UnsafeRawPointer(getMutableRawPointer(memoryType: memoryType))
+extension UnsafeMutableRawPointer: PointerConformance {
+    init(pointer: OpaquePointer) {
+        self = UnsafeMutableRawPointer(pointer)
+    }
 }
+
+extension UnsafePointer: PointerConformance {
+    init(pointer: OpaquePointer) {
+        self = UnsafePointer(pointer)
+    }
+}
+
+extension UnsafeRawPointer: PointerConformance {
+    init(pointer: OpaquePointer) {
+        self = UnsafeRawPointer(pointer)
+    }
+}
+
+
+

--- a/Source/AwsCommonRuntimeKit/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/Utilities.swift
@@ -62,39 +62,22 @@ func fromPointer<T, P: PointerConformance>(ptr: T?) -> P? {
    if let ptr = ptr {
         let pointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
         pointer.initialize(to: ptr)
-       return P(pointer: OpaquePointer(pointer))
+       return P(OpaquePointer(pointer))
     }
     return nil
 }
 
 protocol PointerConformance {
-
-    init(pointer: OpaquePointer)
+    init(_ pointer: OpaquePointer)
 }
 
-extension UnsafeMutablePointer: PointerConformance {
-    init(pointer: OpaquePointer) {
-        self = UnsafeMutablePointer(pointer)
-    }
-}
+extension UnsafeMutablePointer: PointerConformance {}
 
-extension UnsafeMutableRawPointer: PointerConformance {
-    init(pointer: OpaquePointer) {
-        self = UnsafeMutableRawPointer(pointer)
-    }
-}
+extension UnsafeMutableRawPointer: PointerConformance {}
 
-extension UnsafePointer: PointerConformance {
-    init(pointer: OpaquePointer) {
-        self = UnsafePointer(pointer)
-    }
-}
+extension UnsafePointer: PointerConformance {}
 
-extension UnsafeRawPointer: PointerConformance {
-    init(pointer: OpaquePointer) {
-        self = UnsafeRawPointer(pointer)
-    }
-}
+extension UnsafeRawPointer: PointerConformance {}
 
 
 

--- a/Source/AwsCommonRuntimeKit/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/Utilities.swift
@@ -74,7 +74,7 @@ func fromOptionalPointer<T, P: PointerConformance>(ptr: T?) -> P? {
     return nil
 }
 
-func allocate<T>(_ capacity: Int = 1) -> UnsafeMutablePointer<T> {
+func allocatePointer<T>(_ capacity: Int = 1) -> UnsafeMutablePointer<T> {
     let ptr = UnsafeMutablePointer<T>.allocate(capacity: capacity)
     zeroStruct(ptr)
     return ptr

--- a/Source/AwsCommonRuntimeKit/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/Utilities.swift
@@ -8,23 +8,23 @@ import AwsCCommon
 
 @inlinable
 func zeroStruct<T>(_ ptr: UnsafeMutablePointer<T>) {
-  memset(ptr, 0x00, MemoryLayout<T>.size)
+    memset(ptr, 0x00, MemoryLayout<T>.size)
 }
 
 extension Data {
-  @inlinable
-  var awsByteCursor: aws_byte_cursor {
-    return withUnsafeBytes { (rawPtr: UnsafeRawBufferPointer) -> aws_byte_cursor in
-      return aws_byte_cursor_from_array(rawPtr.baseAddress, self.count)
+    @inlinable
+    var awsByteCursor: aws_byte_cursor {
+        return withUnsafeBytes { (rawPtr: UnsafeRawBufferPointer) -> aws_byte_cursor in
+            return aws_byte_cursor_from_array(rawPtr.baseAddress, self.count)
+        }
     }
-  }
 }
 
 extension String {
-  @inlinable
-  var awsByteCursor: aws_byte_cursor {
-    return aws_byte_cursor_from_c_str(self.asCStr())
-  }
+    @inlinable
+    var awsByteCursor: aws_byte_cursor {
+        return aws_byte_cursor_from_c_str(self.asCStr())
+    }
 }
 
 public extension Int32 {

--- a/Source/AwsCommonRuntimeKit/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/Utilities.swift
@@ -57,3 +57,25 @@ extension Bool {
         return self ? 1 : 0
     }
 }
+
+func getMutablePointer<T>(memoryType: T?) -> UnsafeMutablePointer<T>? {
+    if let memoryType = memoryType {
+        let pointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
+        pointer.initialize(to: memoryType)
+        return pointer
+    }
+
+    return nil
+}
+
+func getMutableRawPointer<T>(memoryType: T?) -> UnsafeMutableRawPointer? {
+    return UnsafeMutableRawPointer(getMutablePointer(memoryType: memoryType))
+}
+
+func getUnsafePointer<T>(memoryType: T?) -> UnsafePointer<T>? {
+    return UnsafePointer(getMutablePointer(memoryType: memoryType))
+}
+
+func getUnsafeRawPointer<T>(memoryType: T?) -> UnsafeRawPointer? {
+    return UnsafeRawPointer(getMutableRawPointer(memoryType: memoryType))
+}

--- a/Source/AwsCommonRuntimeKit/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/Utilities.swift
@@ -100,6 +100,3 @@ extension UnsafeMutableRawPointer: PointerConformance {}
 extension UnsafePointer: PointerConformance {}
 
 extension UnsafeRawPointer: PointerConformance {}
-
-
-

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
@@ -211,7 +211,7 @@ public final class CRTAWSCredentialsProvider {
                 future.fail(crtError)
             }
         }
-        let pointer:UnsafeMutablePointer<CRTCredentialsProviderCallbackData> = fromPointer(ptr: callbackData)
+        let pointer: UnsafeMutablePointer<CRTCredentialsProviderCallbackData> = fromPointer(ptr: callbackData)
         aws_credentials_provider_get_credentials(rawValue, { (credentials, errorCode, userdata) -> Void in
             guard let userdata = userdata else {
                 return

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
@@ -167,7 +167,7 @@ public final class CRTAWSCredentialsProvider {
         }
         self.init(credentialsProvider: provider, allocator: allocator)
     }
-    #if os(macOS)
+#if os(macOS)
     /// Creates a credentials provider that sources credentials from IoT Core.
     ///
     /// - Parameters:
@@ -195,7 +195,7 @@ public final class CRTAWSCredentialsProvider {
         }
         self.init(credentialsProvider: provider, allocator: allocator)
     }
-    #endif
+#endif
 
     /// Retrieves credentials from a provider by calling its implementation of get credentials and returns them to
     /// the callback passed in.
@@ -229,5 +229,4 @@ public final class CRTAWSCredentialsProvider {
     deinit {
         aws_credentials_provider_release(rawValue)
     }
-
 }

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
@@ -211,8 +211,7 @@ public final class CRTAWSCredentialsProvider {
                 future.fail(crtError)
             }
         }
-        let pointer = UnsafeMutablePointer<CRTCredentialsProviderCallbackData>.allocate(capacity: 1)
-        pointer.initialize(to: callbackData)
+        let pointer:UnsafeMutablePointer<CRTCredentialsProviderCallbackData> = fromPointer(ptr: callbackData)
         aws_credentials_provider_get_credentials(rawValue, { (credentials, errorCode, userdata) -> Void in
             guard let userdata = userdata else {
                 return

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CRTCredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CRTCredentialsProvider.swift
@@ -20,7 +20,7 @@ private func getCredentialsFn(_ credentialsProviderPtr: UnsafeMutablePointer<aws
         }
     }
     credentialsProvider.pointee.getCredentials(credentialCallbackData: credentialCallbackData)
-   return 0
+    return 0
 }
 
 public protocol CRTCredentialsProvider {
@@ -48,8 +48,7 @@ class WrappedCRTCredentialsProvider {
 
         })
         let shutDownOptions = Self.setUpShutDownOptions(shutDownOptions: shutDownOptions)
-        let intPointer: UnsafeMutableRawPointer = fromPointer(ptr: 1)
-        let atomicVar = aws_atomic_var(value: intPointer)
+        let atomicVar = Atomic<Int>(1)
         self.allocator = allocator
         let credProviderPtr: UnsafeMutablePointer<CRTCredentialsProvider> = fromPointer(ptr: impl)
         let vTablePtr: UnsafeMutablePointer<aws_credentials_provider_vtable> = fromPointer(ptr: vtable)
@@ -59,7 +58,7 @@ class WrappedCRTCredentialsProvider {
                                                  allocator: allocator.rawValue,
                                                  shutdown_options: shutDownOptions,
                                                  impl: credProviderPtr,
-                                                 ref_count: atomicVar)
+                                                 ref_count: atomicVar.rawValue)
 
     }
 

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CRTCredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CRTCredentialsProvider.swift
@@ -48,14 +48,11 @@ class WrappedCRTCredentialsProvider {
 
         })
         let shutDownOptions = Self.setUpShutDownOptions(shutDownOptions: shutDownOptions)
-        let intPointer = UnsafeMutablePointer<Int>.allocate(capacity: 1)
-        intPointer.pointee = 1
+        let intPointer: UnsafeMutablePointer<Int> = fromPointer(ptr: 1)
         let atomicVar = aws_atomic_var(value: UnsafeMutableRawPointer(intPointer))
         self.allocator = allocator
-        let credProviderPtr = UnsafeMutablePointer<CRTCredentialsProvider>.allocate(capacity: 1)
-        credProviderPtr.initialize(to: impl)
-        let vTablePtr = UnsafeMutablePointer<aws_credentials_provider_vtable>.allocate(capacity: 1)
-        vTablePtr.initialize(to: vtable)
+        let credProviderPtr: UnsafeMutablePointer<CRTCredentialsProvider> = fromPointer(ptr: impl)
+        let vTablePtr: UnsafeMutablePointer<aws_credentials_provider_vtable> = fromPointer(ptr: vtable)
         self.vTablePtr = vTablePtr
         self.implementationPtr = credProviderPtr
         self.rawValue = aws_credentials_provider(vtable: vTablePtr,
@@ -70,9 +67,7 @@ class WrappedCRTCredentialsProvider {
     -> aws_credentials_provider_shutdown_options {
         let shutDownOptionsC: aws_credentials_provider_shutdown_options?
         if let shutDownOptions = shutDownOptions {
-
-            let pointer = UnsafeMutablePointer<CRTCredentialsProviderShutdownOptions>.allocate(capacity: 1)
-            pointer.initialize(to: shutDownOptions)
+            let pointer: UnsafeMutablePointer<CRTCredentialsProviderShutdownOptions> = fromPointer(ptr: shutDownOptions)
             shutDownOptionsC = aws_credentials_provider_shutdown_options(shutdown_callback: { userData in
                 guard let userData = userData else {
                     return

--- a/Source/AwsCommonRuntimeKit/auth/signing/SigV4HttpRequestSigner.swift
+++ b/Source/AwsCommonRuntimeKit/auth/signing/SigV4HttpRequestSigner.swift
@@ -63,8 +63,7 @@ public class SigV4HttpRequestSigner {
                                                signable: signable,
                                                onSigningComplete: onSigningComplete)
 
-        let configPointer = UnsafeMutablePointer<aws_signing_config_aws>.allocate(capacity: 1)
-        configPointer.initialize(to: config.rawValue)
+        let configPointer: UnsafeMutablePointer<aws_signing_config_aws> = fromPointer(ptr: config.rawValue)
         let base = configPointer.withMemoryRebound(to: aws_signing_config_base.self,
                                                    capacity: 1) { (configPointer)
             -> UnsafeMutablePointer<aws_signing_config_base> in
@@ -72,8 +71,7 @@ public class SigV4HttpRequestSigner {
         }
         let configPtr = UnsafePointer(base)
 
-        let callbackPointer = UnsafeMutablePointer<SigningCallbackData>.allocate(capacity: 1)
-        callbackPointer.initialize(to: callbackData)
+        let callbackPointer: UnsafeMutablePointer<SigningCallbackData> = fromPointer(ptr: callbackData)
 
         defer {
             base.deinitializeAndDeallocate()

--- a/Source/AwsCommonRuntimeKit/auth/signing/SigningConfig.swift
+++ b/Source/AwsCommonRuntimeKit/auth/signing/SigningConfig.swift
@@ -66,7 +66,7 @@ public struct SigningConfig {
                                                     return true
                                                 }
                                                },
-                                               should_sign_header_ud: fromPointer(ptr: shouldSignHeader),
+                                               should_sign_header_ud: fromOptionalPointer(ptr: shouldSignHeader),
                                                flags: flags.rawValue,
                                                signed_body_value: signedBodyValue.rawValue.awsByteCursor,
                                                signed_body_header: signedBodyHeader.rawValue,

--- a/Source/AwsCommonRuntimeKit/auth/signing/SigningConfig.swift
+++ b/Source/AwsCommonRuntimeKit/auth/signing/SigningConfig.swift
@@ -66,24 +66,13 @@ public struct SigningConfig {
                                                     return true
                                                 }
                                                },
-                                               should_sign_header_ud: SigningConfig.getShouldSignHeaderPointer(shouldSignHeader: shouldSignHeader),
+                                               should_sign_header_ud: getMutableRawPointer(memoryType: shouldSignHeader),
                                                flags: flags.rawValue,
                                                signed_body_value: signedBodyValue.rawValue.awsByteCursor,
                                                signed_body_header: signedBodyHeader.rawValue,
                                                credentials: credentials?.rawValue,
                                                credentials_provider: credentialsProvider?.rawValue,
                                                expiration_in_seconds: UInt64(expiration))
-
-    }
-
-    static func getShouldSignHeaderPointer(shouldSignHeader: ShouldSignHeader?) -> UnsafeMutableRawPointer? {
-        if let shouldSignHeader = shouldSignHeader {
-            let pointer = UnsafeMutablePointer<(String) -> Bool>.allocate(capacity: 1)
-            pointer.initialize(to: shouldSignHeader)
-            return UnsafeMutableRawPointer(pointer)
-        }
-
-        return nil
     }
 }
 

--- a/Source/AwsCommonRuntimeKit/auth/signing/SigningConfig.swift
+++ b/Source/AwsCommonRuntimeKit/auth/signing/SigningConfig.swift
@@ -66,7 +66,7 @@ public struct SigningConfig {
                                                     return true
                                                 }
                                                },
-                                               should_sign_header_ud: getMutableRawPointer(memoryType: shouldSignHeader),
+                                               should_sign_header_ud: fromPointer(ptr: shouldSignHeader),
                                                flags: flags.rawValue,
                                                signed_body_value: signedBodyValue.rawValue.awsByteCursor,
                                                signed_body_header: signedBodyHeader.rawValue,

--- a/Source/AwsCommonRuntimeKit/crt/AWSDate.swift
+++ b/Source/AwsCommonRuntimeKit/crt/AWSDate.swift
@@ -38,24 +38,22 @@ public class AWSDate: Comparable {
     }
 
     public init() {
-        self.rawValue = UnsafeMutablePointer<aws_date_time>.allocate(capacity: 1)
-        rawValue.initialize(to: aws_date_time())
+        self.rawValue = fromPointer(ptr: aws_date_time())
         aws_date_time_init_now(rawValue)
     }
     public init(epochMs: UInt64) {
-        self.rawValue = UnsafeMutablePointer<aws_date_time>.allocate(capacity: 1)
+        self.rawValue = allocatePointer()
         aws_date_time_init_epoch_millis(rawValue, epochMs)
     }
 
     public init(epochS: Double) {
-        self.rawValue = UnsafeMutablePointer<aws_date_time>.allocate(capacity: 1)
+        self.rawValue = allocatePointer()
         aws_date_time_init_epoch_secs(rawValue, epochS)
     }
 
     public init(timestamp: String) {
-        self.rawValue = UnsafeMutablePointer<aws_date_time>.allocate(capacity: 1)
-        let pointer = UnsafeMutablePointer<aws_byte_cursor>.allocate(capacity: 1)
-        pointer.initialize(to: timestamp.awsByteCursor)
+        self.rawValue = allocatePointer()
+        let pointer: UnsafeMutablePointer<aws_byte_cursor> = fromPointer(ptr: timestamp.awsByteCursor)
         defer { pointer.deinitializeAndDeallocate()}
         aws_date_time_init_from_str_cursor(rawValue, pointer, DateFormat.autoDetect.rawValue)
     }
@@ -105,7 +103,7 @@ public class AWSDate: Comparable {
 
 extension AWSDate {
     func toLocalTimeString(format: DateFormat) -> String? {
-        let stringPtr = UnsafeMutablePointer<aws_byte_buf>.allocate(capacity: 1)
+        let stringPtr: UnsafeMutablePointer<aws_byte_buf> = allocatePointer()
         if aws_date_time_to_local_time_str(rawValue, format.rawValue, stringPtr) == AWS_OP_SUCCESS {
             let byteCursor = aws_byte_cursor_from_buf(stringPtr)
             return byteCursor.toString()
@@ -115,7 +113,7 @@ extension AWSDate {
     }
 
     func toGMTString(format: DateFormat) -> String? {
-       let stringPtr = UnsafeMutablePointer<aws_byte_buf>.allocate(capacity: 1)
+        let stringPtr: UnsafeMutablePointer<aws_byte_buf> = allocatePointer()
         if aws_date_time_to_utc_time_str(rawValue, format.rawValue, stringPtr) == AWS_OP_SUCCESS {
             let byteCursor = aws_byte_cursor_from_buf(stringPtr)
             return byteCursor.toString()

--- a/Source/AwsCommonRuntimeKit/crt/Atomic.swift
+++ b/Source/AwsCommonRuntimeKit/crt/Atomic.swift
@@ -1,0 +1,13 @@
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0.
+import AwsCCommon
+
+struct Atomic<I> {
+    let pointer: UnsafeMutableRawPointer
+    let rawValue: aws_atomic_var
+    init(_ type: I) {
+        let pointer: UnsafeMutableRawPointer = fromPointer(ptr: type)
+        self.rawValue = aws_atomic_var(value: pointer)
+        self.pointer = pointer
+    }
+}

--- a/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
@@ -280,7 +280,7 @@ extension ByteBuffer {
         }
 
         let bufferSize = 1024
-        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        let buffer: UnsafeMutablePointer<UInt8> = allocatePointer(bufferSize)
         defer {
             buffer.deallocate()
         }

--- a/Source/AwsCommonRuntimeKit/crt/ShutDownCallbackOptions.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ShutDownCallbackOptions.swift
@@ -16,3 +16,20 @@ public struct ShutDownCallbackOptions {
         self.semaphore = DispatchSemaphore(value: 0)
     }
 }
+
+extension ShutDownCallbackOptions {
+    func toShutDownCPointer() -> UnsafePointer<aws_shutdown_callback_options>? {
+        let shutDownPtr: UnsafeMutablePointer<ShutDownCallbackOptions>? = fromOptionalPointer(ptr: self)
+        let options = aws_shutdown_callback_options(shutdown_callback_fn: { (userData) in
+            guard let userdata = userData else {
+                return
+            }
+            let pointer = userdata.assumingMemoryBound(to: ShutDownCallbackOptions.self)
+            pointer.pointee.shutDownCallback(pointer.pointee.semaphore)
+            pointer.deinitializeAndDeallocate()
+        }, shutdown_callback_user_data: shutDownPtr)
+        let ptr: UnsafePointer<aws_shutdown_callback_options>? = fromOptionalPointer(ptr: options)
+
+        return ptr
+    }
+}

--- a/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
@@ -9,7 +9,7 @@ public class HttpClientConnection {
     private let allocator: Allocator
     let rawValue: UnsafeMutablePointer<aws_http_connection>
     let manager: HttpClientConnectionManager
-    
+
     init(manager: HttpClientConnectionManager,
          connection: UnsafeMutablePointer<aws_http_connection>,
          allocator: Allocator = defaultAllocator) {
@@ -17,16 +17,16 @@ public class HttpClientConnection {
         self.allocator = allocator
         self.rawValue = connection
     }
-    
+
     public var isOpen: Bool {
         return aws_http_connection_is_open(rawValue)
     }
-    
+
     /// Close the http connection
     public func close() {
         manager.releaseConnection(connection: self)
     }
-    
+
     /// Creates a new http stream from the `HttpRequestOptions` given.
     /// - Parameter requestOptions: An `HttpRequestOptions` struct containing callbacks on
     /// the different events from the stream
@@ -36,33 +36,33 @@ public class HttpClientConnection {
         options.self_size = MemoryLayout<aws_http_make_request_options>.size
         options.request = requestOptions.request.rawValue
         options.on_response_body = {_, data, userData -> Int32 in
-            
+
             guard let userData = userData else {
                 return -1
             }
-            
+
             let httpStreamCbData = userData.assumingMemoryBound(to: HttpStreamCallbackData.self)
-            
+
             guard let bufPtr = data?.pointee.ptr,
                   let bufLen = data?.pointee.len,
                   let stream = httpStreamCbData.pointee.stream,
                   let incomingBodyFn = httpStreamCbData.pointee.requestOptions.onIncomingBody else {
                       return -1
                   }
-            
+
             let callbackBytes = Data(bytesNoCopy: bufPtr, count: bufLen, deallocator: .none)
-            
+
             incomingBodyFn(stream, callbackBytes)
-            
+
             return 0
         }
         options.on_response_headers = {_, headerBlock, headerArray, headersCount, userData -> Int32 in
-            
+
             guard let userData = userData else {
                 return -1
             }
             let httpStreamCbData = userData.assumingMemoryBound(to: HttpStreamCallbackData.self)
-            
+
             var headers = [HttpHeader]()
             for cHeader in UnsafeBufferPointer(start: headerArray, count: headersCount) {
                 if let name = cHeader.name.toString(),
@@ -70,10 +70,10 @@ public class HttpClientConnection {
                     let swiftHeader = HttpHeader(name: name, value: value)
                     headers.append(swiftHeader)
                 }
-                
+
             }
             let headersStruct = HttpHeaders(fromArray: headers)
-            
+
             guard let stream = httpStreamCbData.pointee.stream else {
                 return -1
             }
@@ -83,7 +83,7 @@ public class HttpClientConnection {
             return 0
         }
         options.on_response_header_block_done = {_, headerBlock, userData -> Int32 in
-            
+
             guard let userData = userData else {
                 return -1
             }
@@ -92,11 +92,11 @@ public class HttpClientConnection {
                 return -1
             }
             httpStreamCbData.pointee.requestOptions.onIncomingHeadersBlockDone(stream, HttpHeaderBlock(rawValue: headerBlock))
-            
+
             return 0
         }
         options.on_complete = {_, errorCode, userData in
-            
+
             guard let userData = userData else {
                 return
             }
@@ -108,17 +108,17 @@ public class HttpClientConnection {
                   }
             onStreamCompleteFn(stream, CRTError.crtError(error))
         }
-        
+
         let cbData = HttpStreamCallbackData(requestOptions: requestOptions)
         options.user_data = getMutableRawPointer(memoryType: cbData)
-        
+
         let stream = HttpStream(httpConnection: self)
         cbData.stream = stream
         stream.httpStream = aws_http_connection_make_request(rawValue, &options)
-        
+
         return stream
     }
-    
+
     deinit {
         aws_http_connection_release(rawValue)
     }

--- a/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
@@ -110,7 +110,7 @@ public class HttpClientConnection {
         }
 
         let cbData = HttpStreamCallbackData(requestOptions: requestOptions)
-        options.user_data = fromPointer(ptr: cbData)
+        options.user_data = fromOptionalPointer(ptr: cbData)
 
         let stream = HttpStream(httpConnection: self)
         cbData.stream = stream

--- a/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
@@ -9,7 +9,7 @@ public class HttpClientConnection {
     private let allocator: Allocator
     let rawValue: UnsafeMutablePointer<aws_http_connection>
     let manager: HttpClientConnectionManager
-
+    
     init(manager: HttpClientConnectionManager,
          connection: UnsafeMutablePointer<aws_http_connection>,
          allocator: Allocator = defaultAllocator) {
@@ -17,16 +17,16 @@ public class HttpClientConnection {
         self.allocator = allocator
         self.rawValue = connection
     }
-
+    
     public var isOpen: Bool {
         return aws_http_connection_is_open(rawValue)
     }
-
+    
     /// Close the http connection
     public func close() {
         manager.releaseConnection(connection: self)
     }
-
+    
     /// Creates a new http stream from the `HttpRequestOptions` given.
     /// - Parameter requestOptions: An `HttpRequestOptions` struct containing callbacks on
     /// the different events from the stream
@@ -36,7 +36,7 @@ public class HttpClientConnection {
         options.self_size = MemoryLayout<aws_http_make_request_options>.size
         options.request = requestOptions.request.rawValue
         options.on_response_body = {_, data, userData -> Int32 in
-
+            
             guard let userData = userData else {
                 return -1
             }
@@ -47,22 +47,22 @@ public class HttpClientConnection {
                   let bufLen = data?.pointee.len,
                   let stream = httpStreamCbData.pointee.stream,
                   let incomingBodyFn = httpStreamCbData.pointee.requestOptions.onIncomingBody else {
-                return -1
-            }
-
+                      return -1
+                  }
+            
             let callbackBytes = Data(bytesNoCopy: bufPtr, count: bufLen, deallocator: .none)
-
+            
             incomingBodyFn(stream, callbackBytes)
-
+            
             return 0
         }
         options.on_response_headers = {_, headerBlock, headerArray, headersCount, userData -> Int32 in
-
+            
             guard let userData = userData else {
                 return -1
             }
             let httpStreamCbData = userData.assumingMemoryBound(to: HttpStreamCallbackData.self)
-
+            
             var headers = [HttpHeader]()
             for cHeader in UnsafeBufferPointer(start: headerArray, count: headersCount) {
                 if let name = cHeader.name.toString(),
@@ -70,54 +70,55 @@ public class HttpClientConnection {
                     let swiftHeader = HttpHeader(name: name, value: value)
                     headers.append(swiftHeader)
                 }
-
+                
             }
             let headersStruct = HttpHeaders(fromArray: headers)
             
-            guard let stream = httpStreamCbData.pointee.stream,
-                  let incomingHeadersFn = httpStreamCbData.pointee.requestOptions.onIncomingHeaders else {
-                      return - 1
-                  }
-            incomingHeadersFn(stream,
-                              HttpHeaderBlock(rawValue: headerBlock),
-                              headersStruct )
+            guard let stream = httpStreamCbData.pointee.stream else {
+                return -1
+            }
+            httpStreamCbData.pointee.requestOptions.onIncomingHeaders(stream,
+                                                                      HttpHeaderBlock(rawValue: headerBlock),
+                                                                      headersStruct )
             return 0
         }
         options.on_response_header_block_done = {_, headerBlock, userData -> Int32 in
-
+            
             guard let userData = userData else {
                 return -1
             }
             let httpStreamCbData = userData.assumingMemoryBound(to: HttpStreamCallbackData.self)
-            guard let stream = httpStreamCbData.pointee.stream,
-                  let incomingHeadersBlockDoneFn = httpStreamCbData.pointee.requestOptions.onIncomingHeadersBlockDone else {
-                      return -1
-                  }
-            incomingHeadersBlockDoneFn(stream, HttpHeaderBlock(rawValue: headerBlock))
-    
+            guard let stream = httpStreamCbData.pointee.stream else {
+                return -1
+            }
+            httpStreamCbData.pointee.requestOptions.onIncomingHeadersBlockDone(stream, HttpHeaderBlock(rawValue: headerBlock))
+            
             return 0
         }
         options.on_complete = {_, errorCode, userData in
-
+            
             guard let userData = userData else {
                 return
             }
-            let httpStreamCbData: HttpStreamCallbackData = Unmanaged.fromOpaque(userData).takeUnretainedValue()
+            let httpStreamCbData = userData.assumingMemoryBound(to: HttpStreamCallbackData.self)
             let error = AWSError(errorCode: errorCode)
-
-            httpStreamCbData.requestOptions.onStreamComplete!(httpStreamCbData.stream!, CRTError.crtError(error))
+            guard let stream = httpStreamCbData.pointee.stream,
+                  let onStreamCompleteFn = httpStreamCbData.pointee.requestOptions.onStreamComplete else {
+                      return
+                  }
+            onStreamCompleteFn(stream, CRTError.crtError(error))
         }
-
+        
         let cbData = HttpStreamCallbackData(requestOptions: requestOptions)
         options.user_data = getMutableRawPointer(memoryType: cbData)
-
+        
         let stream = HttpStream(httpConnection: self)
         cbData.stream = stream
         stream.httpStream = aws_http_connection_make_request(rawValue, &options)
-
+        
         return stream
     }
-
+    
     deinit {
         aws_http_connection_release(rawValue)
     }

--- a/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
@@ -110,7 +110,7 @@ public class HttpClientConnection {
         }
 
         let cbData = HttpStreamCallbackData(requestOptions: requestOptions)
-        options.user_data = getMutableRawPointer(memoryType: cbData)
+        options.user_data = fromPointer(ptr: cbData)
 
         let stream = HttpStream(httpConnection: self)
         cbData.stream = stream

--- a/Source/AwsCommonRuntimeKit/http/HttpClientConnectionManager.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpClientConnectionManager.swift
@@ -14,10 +14,8 @@ public class HttpClientConnectionManager {
     public init(options: HttpClientConnectionOptions, allocator: Allocator = defaultAllocator) {
         self.options = options
         self.allocator = allocator
-        let shutDownPtr = UnsafeMutablePointer<ShutDownCallbackOptions>.allocate(capacity: 1)
-        if let shutDownOptions = options.shutDownOptions {
-        shutDownPtr.initialize(to: shutDownOptions)
-        }
+        let shutDownPtr: UnsafeMutablePointer<ShutDownCallbackOptions>? = fromOptionalPointer(ptr: options.shutDownOptions)
+
         var mgrOptions = aws_http_connection_manager_options(bootstrap: options.clientBootstrap.rawValue,
                                                              initial_window_size: options.initialWindowSize,
                                                              socket_options: options.socketOptions.rawValue,
@@ -66,8 +64,7 @@ public class HttpClientConnectionManager {
         let callbackData = HttpClientConnectionCallbackData(onConnectionAcquired: onConnectionAcquired,
                                                             connectionManager: self,
                                                             allocator: allocator)
-        let cbData = UnsafeMutablePointer<HttpClientConnectionCallbackData>.allocate(capacity: 1)
-        cbData.initialize(to: callbackData)
+        let cbData: UnsafeMutablePointer<HttpClientConnectionCallbackData> = fromPointer(ptr: callbackData)
 
         aws_http_connection_manager_acquire_connection(manager, { (connection, errorCode, userData) in
             guard let userData = userData else {

--- a/Source/AwsCommonRuntimeKit/http/HttpMonitoringOptions.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpMonitoringOptions.swift
@@ -20,8 +20,7 @@ public class HttpMonitoringOptions {
         let options = aws_http_connection_monitoring_options(
             minimum_throughput_bytes_per_second: UInt64(minThroughputBytesPerSecond),
             allowable_throughput_failure_interval_seconds: UInt32(allowableThroughputFailureInterval))
-        let ptr = UnsafeMutablePointer<aws_http_connection_monitoring_options>.allocate(capacity: 1)
-        ptr.initialize(to: options)
+        let ptr: UnsafeMutablePointer<aws_http_connection_monitoring_options> = fromPointer(ptr: options)
         self.rawValue = ptr
 
     }

--- a/Source/AwsCommonRuntimeKit/http/HttpMonitoringOptions.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpMonitoringOptions.swift
@@ -20,8 +20,7 @@ public class HttpMonitoringOptions {
         let options = aws_http_connection_monitoring_options(
             minimum_throughput_bytes_per_second: UInt64(minThroughputBytesPerSecond),
             allowable_throughput_failure_interval_seconds: UInt32(allowableThroughputFailureInterval))
-        let ptr: UnsafeMutablePointer<aws_http_connection_monitoring_options> = fromPointer(ptr: options)
-        self.rawValue = ptr
+        self.rawValue = fromPointer(ptr: options)
 
     }
 

--- a/Source/AwsCommonRuntimeKit/http/HttpProxyOptions.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpProxyOptions.swift
@@ -12,9 +12,7 @@ public class HttpProxyOptions {
     public var tlsOptions: TlsConnectionOptions?
 
     public init(hostName: String, port: UInt16) {
-        let ptr = UnsafeMutablePointer<aws_http_proxy_options>.allocate(capacity: 1)
-        zeroStruct(ptr)
-        self.rawValue = ptr
+        self.rawValue = allocatePointer()
         self.hostName = hostName
         self.port = port
     }

--- a/Source/AwsCommonRuntimeKit/io/ClientBootstrap.swift
+++ b/Source/AwsCommonRuntimeKit/io/ClientBootstrap.swift
@@ -14,10 +14,7 @@ public final class ClientBootstrap {
                 allocator: Allocator = defaultAllocator) throws {
 
         self.callbackData = callbackData
-        let callbackDataPointer = UnsafeMutablePointer<ClientBootstrapCallbackData>.allocate(capacity: 1)
-        if let callbackData = callbackData {
-        callbackDataPointer.initialize(to: callbackData)
-        }
+        let callbackDataPointer: UnsafeMutablePointer<ClientBootstrapCallbackData>? = fromOptionalPointer(ptr: callbackData)
 
         var options = aws_client_bootstrap_options(
             event_loop_group: elg.rawValue,

--- a/Source/AwsCommonRuntimeKit/io/EventLoopGroup.swift
+++ b/Source/AwsCommonRuntimeKit/io/EventLoopGroup.swift
@@ -12,19 +12,7 @@ public final class EventLoopGroup {
     public init(threadCount: UInt16 = 0,
                 allocator: Allocator = defaultAllocator,
                 shutDownOptions: ShutDownCallbackOptions? = nil) {
-        let shutDownPtr: UnsafeMutablePointer<ShutDownCallbackOptions>? = fromOptionalPointer(ptr: shutDownOptions)
-        let options = aws_shutdown_callback_options(shutdown_callback_fn: { (userData) in
-            guard let userdata = userData else {
-                return
-            }
-            let pointer = userdata.assumingMemoryBound(to: ShutDownCallbackOptions.self)
-            defer { pointer.deinitializeAndDeallocate() }
-            pointer.pointee.shutDownCallback(pointer.pointee.semaphore)
-
-        }, shutdown_callback_user_data: shutDownPtr)
-        let ptr: UnsafePointer<aws_shutdown_callback_options>? = fromOptionalPointer(ptr: options)
-
-        defer {ptr?.deallocate()}
+        let ptr = shutDownOptions?.toShutDownCPointer()
         self.shutDownOptions = shutDownOptions
 
         self.rawValue = aws_event_loop_group_new_default(allocator.rawValue, threadCount, ptr)

--- a/Source/AwsCommonRuntimeKit/io/EventLoopGroup.swift
+++ b/Source/AwsCommonRuntimeKit/io/EventLoopGroup.swift
@@ -23,7 +23,7 @@ public final class EventLoopGroup {
 
         }, shutdown_callback_user_data: shutDownPtr)
         let ptr: UnsafePointer<aws_shutdown_callback_options>? = fromOptionalPointer(ptr: options)
-        
+
         defer {ptr?.deallocate()}
         self.shutDownOptions = shutDownOptions
 

--- a/Source/AwsCommonRuntimeKit/io/EventLoopGroup.swift
+++ b/Source/AwsCommonRuntimeKit/io/EventLoopGroup.swift
@@ -12,24 +12,18 @@ public final class EventLoopGroup {
     public init(threadCount: UInt16 = 0,
                 allocator: Allocator = defaultAllocator,
                 shutDownOptions: ShutDownCallbackOptions? = nil) {
-        var ptr: UnsafePointer<aws_shutdown_callback_options>?
-        if let shutDownOptions = shutDownOptions {
-            let shutDownPtr = UnsafeMutablePointer<ShutDownCallbackOptions>.allocate(capacity: 1)
-            shutDownPtr.initialize(to: shutDownOptions)
-            let options = aws_shutdown_callback_options(shutdown_callback_fn: { (userData) in
-                guard let userdata = userData else {
-                    return
-                }
-                let pointer = userdata.assumingMemoryBound(to: ShutDownCallbackOptions.self)
-                defer { pointer.deinitializeAndDeallocate() }
-                pointer.pointee.shutDownCallback(pointer.pointee.semaphore)
+        let shutDownPtr: UnsafeMutablePointer<ShutDownCallbackOptions>? = fromOptionalPointer(ptr: shutDownOptions)
+        let options = aws_shutdown_callback_options(shutdown_callback_fn: { (userData) in
+            guard let userdata = userData else {
+                return
+            }
+            let pointer = userdata.assumingMemoryBound(to: ShutDownCallbackOptions.self)
+            defer { pointer.deinitializeAndDeallocate() }
+            pointer.pointee.shutDownCallback(pointer.pointee.semaphore)
 
-            }, shutdown_callback_user_data: shutDownPtr)
-
-            let mutablePtr = UnsafeMutablePointer<aws_shutdown_callback_options>.allocate(capacity: 1)
-            mutablePtr.initialize(to: options)
-            ptr = UnsafePointer(mutablePtr)
-        }
+        }, shutdown_callback_user_data: shutDownPtr)
+        let ptr: UnsafePointer<aws_shutdown_callback_options>? = fromOptionalPointer(ptr: options)
+        
         defer {ptr?.deallocate()}
         self.shutDownOptions = shutDownOptions
 

--- a/Source/AwsCommonRuntimeKit/io/HostResolver.swift
+++ b/Source/AwsCommonRuntimeKit/io/HostResolver.swift
@@ -39,7 +39,7 @@ public final class DefaultHostResolver: HostResolver {
         }, shutdown_callback_user_data: shutDownPtr)
 
         let shutdownCallbackOptionPtr: UnsafePointer<aws_shutdown_callback_options> = fromPointer(ptr: shutDownCallbackOptions)
-        
+
         self.shutDownOptions = shutDownOptions
         let options = aws_host_resolver_default_options(max_entries: maxHosts,
                                                         el_group: elg.rawValue,
@@ -102,7 +102,7 @@ private func onHostResolved(_ resolver: UnsafeMutablePointer<aws_host_resolver>!
     }
 
     let error = AWSError(errorCode: errorCode)
-    
+
     options.pointee.onResolved(options.pointee.resolver, addresses, CRTError.crtError(error))
     options.deinitializeAndDeallocate()
 }

--- a/Source/AwsCommonRuntimeKit/io/HostResolver.swift
+++ b/Source/AwsCommonRuntimeKit/io/HostResolver.swift
@@ -19,7 +19,7 @@ public final class DefaultHostResolver: HostResolver {
     private let allocator: Allocator
     public let shutDownOptions: ShutDownCallbackOptions?
     var shutdownCallbackOptionPtr: UnsafePointer<aws_shutdown_callback_options>?
-    let hostResolverOptionsPtr = UnsafeMutablePointer<aws_host_resolver_default_options>.allocate(capacity: 1)
+    let hostResolverOptionsPtr: UnsafeMutablePointer<aws_host_resolver_default_options>
 
     public init(eventLoopGroup elg: EventLoopGroup,
                 maxHosts: Int,
@@ -27,30 +27,25 @@ public final class DefaultHostResolver: HostResolver {
                 allocator: Allocator = defaultAllocator,
                 shutDownOptions: ShutDownCallbackOptions? = nil) {
         self.allocator = allocator
+        let shutDownPtr: UnsafeMutablePointer<ShutDownCallbackOptions>? = fromOptionalPointer(ptr: shutDownOptions)
 
-        if let shutDownOptions = shutDownOptions {
-            let shutDownPtr = UnsafeMutablePointer<ShutDownCallbackOptions>.allocate(capacity: 1)
-            shutDownPtr.initialize(to: shutDownOptions)
-            let options = aws_shutdown_callback_options(shutdown_callback_fn: { (userData) in
-                guard let userdata = userData else {
-                    return
-                }
-                let pointer = userdata.assumingMemoryBound(to: ShutDownCallbackOptions.self)
-                defer { pointer.deinitializeAndDeallocate() }
-                pointer.pointee.shutDownCallback(pointer.pointee.semaphore)
-            }, shutdown_callback_user_data: shutDownPtr)
+        let shutDownCallbackOptions = aws_shutdown_callback_options(shutdown_callback_fn: { (userData) in
+            guard let userdata = userData else {
+                return
+            }
+            let pointer = userdata.assumingMemoryBound(to: ShutDownCallbackOptions.self)
+            pointer.pointee.shutDownCallback(pointer.pointee.semaphore)
+            pointer.deinitializeAndDeallocate()
+        }, shutdown_callback_user_data: shutDownPtr)
 
-            let mutablePtr = UnsafeMutablePointer<aws_shutdown_callback_options>.allocate(capacity: 1)
-            mutablePtr.initialize(to: options)
-
-            shutdownCallbackOptionPtr = UnsafePointer(mutablePtr)
-        }
+        let shutdownCallbackOptionPtr: UnsafePointer<aws_shutdown_callback_options> = fromPointer(ptr: shutDownCallbackOptions)
+        
         self.shutDownOptions = shutDownOptions
         let options = aws_host_resolver_default_options(max_entries: maxHosts,
                                                         el_group: elg.rawValue,
                                                         shutdown_options: shutdownCallbackOptionPtr,
                                                         system_clock_override_fn: nil)
-        hostResolverOptionsPtr.initialize(to: options)
+        self.hostResolverOptionsPtr = fromPointer(ptr: options)
         self.rawValue = aws_host_resolver_new_default(allocator.rawValue, hostResolverOptionsPtr)
 
         let config = aws_host_resolution_config(
@@ -59,9 +54,7 @@ public final class DefaultHostResolver: HostResolver {
             impl_data: nil
         )
 
-        let hostResolverConfigPointer = UnsafeMutablePointer<aws_host_resolution_config>.allocate(capacity: 1)
-        hostResolverConfigPointer.initialize(to: config)
-        self.config = hostResolverConfigPointer
+        self.config = fromPointer(ptr: config)
 
     }
 
@@ -79,15 +72,14 @@ public final class DefaultHostResolver: HostResolver {
         let options = ResolverOptions(resolver: self,
                                       host: AWSString(host, allocator: self.allocator),
                                       onResolved: callback)
-        let unmanagedOptions = Unmanaged.passRetained(options)
+        let pointer: UnsafeMutableRawPointer = fromPointer(ptr: options)
 
         if aws_host_resolver_resolve_host(self.rawValue,
                                           options.host.rawValue,
                                           onHostResolved,
                                           self.config,
-                                          unmanagedOptions.toOpaque()) != AWS_OP_SUCCESS {
-            // We have an unbalanced retain on unmanagedOptions, need to release it!
-            defer { unmanagedOptions.release() }
+                                          pointer) != AWS_OP_SUCCESS {
+            pointer.deallocate()
             throw AWSCommonRuntimeError()
         }
     }
@@ -98,8 +90,7 @@ private func onHostResolved(_ resolver: UnsafeMutablePointer<aws_host_resolver>!
                             _ errorCode: Int32,
                             _ hostAddresses: UnsafePointer<aws_array_list>!,
                             _ userData: UnsafeMutableRawPointer!) {
-    // Consumes the unbalanced retain that was made to get the value here
-    let options: ResolverOptions = Unmanaged.fromOpaque(userData).takeRetainedValue()
+    let options = userData.assumingMemoryBound(to: ResolverOptions.self)
 
     let length = aws_array_list_length(hostAddresses)
     var addresses: [HostAddress] = Array(repeating: HostAddress(), count: length)
@@ -111,5 +102,7 @@ private func onHostResolved(_ resolver: UnsafeMutablePointer<aws_host_resolver>!
     }
 
     let error = AWSError(errorCode: errorCode)
-    options.onResolved(options.resolver, addresses, CRTError.crtError(error))
+    
+    options.pointee.onResolved(options.pointee.resolver, addresses, CRTError.crtError(error))
+    options.deinitializeAndDeallocate()
 }

--- a/Source/AwsCommonRuntimeKit/io/HostResolver.swift
+++ b/Source/AwsCommonRuntimeKit/io/HostResolver.swift
@@ -27,18 +27,8 @@ public final class DefaultHostResolver: HostResolver {
                 allocator: Allocator = defaultAllocator,
                 shutDownOptions: ShutDownCallbackOptions? = nil) {
         self.allocator = allocator
-        let shutDownPtr: UnsafeMutablePointer<ShutDownCallbackOptions>? = fromOptionalPointer(ptr: shutDownOptions)
 
-        let shutDownCallbackOptions = aws_shutdown_callback_options(shutdown_callback_fn: { (userData) in
-            guard let userdata = userData else {
-                return
-            }
-            let pointer = userdata.assumingMemoryBound(to: ShutDownCallbackOptions.self)
-            pointer.pointee.shutDownCallback(pointer.pointee.semaphore)
-            pointer.deinitializeAndDeallocate()
-        }, shutdown_callback_user_data: shutDownPtr)
-
-        let shutdownCallbackOptionPtr: UnsafePointer<aws_shutdown_callback_options> = fromPointer(ptr: shutDownCallbackOptions)
+        let shutdownCallbackOptionPtr = shutDownOptions?.toShutDownCPointer()
 
         self.shutDownOptions = shutDownOptions
         let options = aws_host_resolver_default_options(max_entries: maxHosts,

--- a/Source/AwsCommonRuntimeKit/io/SocketOptions.swift
+++ b/Source/AwsCommonRuntimeKit/io/SocketOptions.swift
@@ -17,8 +17,7 @@ public class SocketOptions {
             keep_alive_max_failed_probes: 0,
             keepalive: false
         )
-        let ptr = UnsafeMutablePointer<aws_socket_options>.allocate(capacity: 1)
-        ptr.initialize(to: socketOptions)
+        let ptr: UnsafeMutablePointer<aws_socket_options> = fromPointer(ptr: socketOptions)
         self.rawValue = ptr
     }
 

--- a/Source/AwsCommonRuntimeKit/io/Stream.swift
+++ b/Source/AwsCommonRuntimeKit/io/Stream.swift
@@ -17,9 +17,8 @@ public class AwsInputStream {
 
     public init(_ impl: AwsStream, allocator: Allocator = defaultAllocator) {
         self.length = Int64(impl.length)
-        let ptr:UnsafeMutablePointer<AwsStream> = fromPointer(ptr: impl)
-        self.implPointer = ptr
-        self.rawValue = aws_input_stream(allocator: allocator.rawValue, impl: ptr, vtable: &vtable)
+        self.implPointer = fromPointer(ptr: impl)
+        self.rawValue = aws_input_stream(allocator: allocator.rawValue, impl: self.implPointer, vtable: &vtable)
     }
     
     deinit {

--- a/Source/AwsCommonRuntimeKit/io/Stream.swift
+++ b/Source/AwsCommonRuntimeKit/io/Stream.swift
@@ -17,8 +17,7 @@ public class AwsInputStream {
 
     public init(_ impl: AwsStream, allocator: Allocator = defaultAllocator) {
         self.length = Int64(impl.length)
-        let ptr = UnsafeMutablePointer<AwsStream>.allocate(capacity: 1)
-        ptr.initialize(to: impl)
+        let ptr:UnsafeMutablePointer<AwsStream> = fromPointer(ptr: impl)
         self.implPointer = ptr
         self.rawValue = aws_input_stream(allocator: allocator.rawValue, impl: ptr, vtable: &vtable)
     }
@@ -78,7 +77,7 @@ extension FileHandle: AwsStream {
 private func doSeek(_ stream: UnsafeMutablePointer<aws_input_stream>!,
                     _ offset: Int64,
                     _ seekBasis: aws_stream_seek_basis) -> Int32 {
-    let inputStream = stream.pointee.impl.bindMemory(to: AwsStream.self, capacity: 1).pointee
+    let inputStream = stream.pointee.impl.assumingMemoryBound(to: AwsStream.self).pointee
     if inputStream.seek(offset: offset, basis: seekBasis) {
         return AWS_OP_SUCCESS
     }
@@ -96,14 +95,14 @@ private func doRead(_ stream: UnsafeMutablePointer<aws_input_stream>!,
 
 private func doGetStatus(_ stream: UnsafeMutablePointer<aws_input_stream>!,
                          _ result: UnsafeMutablePointer<aws_stream_status>!) -> Int32 {
-    let inputStream = stream.pointee.impl.bindMemory(to: AwsStream.self, capacity: 1).pointee
+    let inputStream = stream.pointee.impl.assumingMemoryBound(to: AwsStream.self).pointee
     result.pointee = inputStream.status
     return AWS_OP_SUCCESS
 }
 
 private func doGetLength(_ stream: UnsafeMutablePointer<aws_input_stream>!,
                          _ result: UnsafeMutablePointer<Int64>!) -> Int32 {
-    let inputStream = stream.pointee.impl.bindMemory(to: AwsStream.self, capacity: 1).pointee
+    let inputStream = stream.pointee.impl.assumingMemoryBound(to: AwsStream.self).pointee
     let length = inputStream.length
   
     result.pointee = Int64(length)

--- a/Source/AwsCommonRuntimeKit/io/TlsConnectionOptions.swift
+++ b/Source/AwsCommonRuntimeKit/io/TlsConnectionOptions.swift
@@ -10,7 +10,7 @@ public final class TlsConnectionOptions {
 	init(_ context: TlsContext, allocator: Allocator) {
 		self.allocator = allocator
 
-        self.rawValue = allocate()
+        self.rawValue = allocatePointer()
 		aws_tls_connection_options_init_from_ctx(rawValue, context.rawValue)
 	}
 

--- a/Source/AwsCommonRuntimeKit/io/TlsConnectionOptions.swift
+++ b/Source/AwsCommonRuntimeKit/io/TlsConnectionOptions.swift
@@ -9,10 +9,8 @@ public final class TlsConnectionOptions {
 
 	init(_ context: TlsContext, allocator: Allocator) {
 		self.allocator = allocator
-        let connectionOptionsPtr = UnsafeMutablePointer<aws_tls_connection_options>.allocate(capacity: 1)
-        //initialize pointer to empty connection options struct
-        zeroStruct(connectionOptionsPtr)
-        self.rawValue = connectionOptionsPtr
+
+        self.rawValue = allocate()
 		aws_tls_connection_options_init_from_ctx(rawValue, context.rawValue)
 	}
 

--- a/Source/AwsCommonRuntimeKit/io/TlsContextOptions.swift
+++ b/Source/AwsCommonRuntimeKit/io/TlsContextOptions.swift
@@ -11,9 +11,7 @@ public final class TlsContextOptions {
     }
     
     public init(defaultClientWithAllocator allocator: Allocator = defaultAllocator) {
-        let optionsPtr = UnsafeMutablePointer<aws_tls_ctx_options>.allocate(capacity: 1)
-        zeroStruct(optionsPtr)
-        self.rawValue = optionsPtr
+        self.rawValue = allocate()
         aws_tls_ctx_options_init_default_client(rawValue, allocator.rawValue)
     }
     
@@ -21,11 +19,8 @@ public final class TlsContextOptions {
     public init(clientWithMtlsCertificatePath certPath: String,
                 keyPath: String,
                 allocator: Allocator = defaultAllocator) throws {
-        let ptr = UnsafeMutablePointer<aws_byte_cursor>.allocate(capacity: 1)
-        ptr.initialize(to: keyPath.awsByteCursor)
-        let optionsPtr = UnsafeMutablePointer<aws_tls_ctx_options>.allocate(capacity: 1)
-        zeroStruct(optionsPtr)
-        self.rawValue = optionsPtr
+        let ptr: UnsafeMutablePointer<aws_byte_cursor> = fromPointer(ptr: keyPath.awsByteCursor)
+        self.rawValue = allocate()
         if aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(rawValue,
                                                                  allocator.rawValue,
                                                                  certPath, ptr) != AWS_OP_SUCCESS {
@@ -36,9 +31,7 @@ public final class TlsContextOptions {
     public init(clientWithMtlsCert cert: inout ByteCursor,
                 key: inout ByteCursor,
                 allocator: Allocator = defaultAllocator) throws {
-        let optionsPtr = UnsafeMutablePointer<aws_tls_ctx_options>.allocate(capacity: 1)
-        zeroStruct(optionsPtr)
-        self.rawValue = optionsPtr
+        self.rawValue = allocate()
         if aws_tls_ctx_options_init_client_mtls_pkcs12(rawValue,
                                                        allocator.rawValue,
                                                        &cert.rawValue,
@@ -52,9 +45,7 @@ public final class TlsContextOptions {
     public init(clientWithMtlsPkcs12Path path: String,
                 password: String,
                 allocator: Allocator = defaultAllocator) throws {
-        let optionsPtr = UnsafeMutablePointer<aws_tls_ctx_options>.allocate(capacity: 1)
-        zeroStruct(optionsPtr)
-        self.rawValue = optionsPtr
+        self.rawValue = allocate()
         var passwordCursor = password.newByteCursor()
         if aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(rawValue,
                                                                  allocator.rawValue,

--- a/Source/AwsCommonRuntimeKit/io/TlsContextOptions.swift
+++ b/Source/AwsCommonRuntimeKit/io/TlsContextOptions.swift
@@ -11,7 +11,7 @@ public final class TlsContextOptions {
     }
     
     public init(defaultClientWithAllocator allocator: Allocator = defaultAllocator) {
-        self.rawValue = allocate()
+        self.rawValue = allocatePointer()
         aws_tls_ctx_options_init_default_client(rawValue, allocator.rawValue)
     }
     
@@ -20,7 +20,7 @@ public final class TlsContextOptions {
                 keyPath: String,
                 allocator: Allocator = defaultAllocator) throws {
         let ptr: UnsafeMutablePointer<aws_byte_cursor> = fromPointer(ptr: keyPath.awsByteCursor)
-        self.rawValue = allocate()
+        self.rawValue = allocatePointer()
         if aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(rawValue,
                                                                  allocator.rawValue,
                                                                  certPath, ptr) != AWS_OP_SUCCESS {
@@ -31,7 +31,7 @@ public final class TlsContextOptions {
     public init(clientWithMtlsCert cert: inout ByteCursor,
                 key: inout ByteCursor,
                 allocator: Allocator = defaultAllocator) throws {
-        self.rawValue = allocate()
+        self.rawValue = allocatePointer()
         if aws_tls_ctx_options_init_client_mtls_pkcs12(rawValue,
                                                        allocator.rawValue,
                                                        &cert.rawValue,
@@ -45,7 +45,7 @@ public final class TlsContextOptions {
     public init(clientWithMtlsPkcs12Path path: String,
                 password: String,
                 allocator: Allocator = defaultAllocator) throws {
-        self.rawValue = allocate()
+        self.rawValue = allocatePointer()
         var passwordCursor = password.newByteCursor()
         if aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(rawValue,
                                                                  allocator.rawValue,

--- a/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryStrategy.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryStrategy.swift
@@ -52,10 +52,8 @@ public final class CRTAWSRetryStrategy {
             }
         }
 
-        let pointer = UnsafeMutablePointer<CRTAcquireTokenCallbackData>.allocate(capacity: 1)
-        pointer.initialize(to: callbackData)
-        let partitionPtr = UnsafeMutablePointer<aws_byte_cursor>.allocate(capacity: 1)
-        partitionPtr.initialize(to: partitionId.awsByteCursor)
+        let pointer: UnsafeMutablePointer<CRTAcquireTokenCallbackData> = fromPointer(ptr: callbackData)
+        let partitionPtr: UnsafeMutablePointer<aws_byte_cursor> = fromPointer(ptr: partitionId.awsByteCursor)
         aws_retry_strategy_acquire_retry_token(rawValue, partitionPtr, { retryerPointer, errorCode, token, userdata in
             guard let userdata = userdata,
                   let token = token else {
@@ -81,8 +79,7 @@ public final class CRTAWSRetryStrategy {
             }
         }
 
-        let pointer = UnsafeMutablePointer<CRTScheduleRetryCallbackData>.allocate(capacity: 1)
-        pointer.initialize(to: callbackData)
+        let pointer: UnsafeMutablePointer<CRTScheduleRetryCallbackData> = fromPointer(ptr: callbackData)
 
         aws_retry_strategy_schedule_retry(token.rawValue, errorType.rawValue, { retryToken, errorCode, userdata in
             guard let userdata = userdata,

--- a/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryToken.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryToken.swift
@@ -7,13 +7,12 @@ public final class CRTAWSRetryToken {
     var rawValue: UnsafeMutablePointer<aws_retry_token>
 
     public init(retryStrategy: CRTRetryStrategy, allocator: Allocator = defaultAllocator) {
-        let intPointer: UnsafeMutableRawPointer = fromPointer(ptr: 1)
-        let atomicVar = aws_atomic_var(value: intPointer)
+        let atomicVar = Atomic<Int>(1)
         let retryStrategyPtr: UnsafeMutablePointer<CRTRetryStrategy> = fromPointer(ptr: retryStrategy)
         let retryToken = aws_retry_token(allocator: allocator.rawValue,
-                                        retry_strategy: retryStrategy.rawValue,
-                                        ref_count: atomicVar,
-                                        impl: retryStrategyPtr)
+                                         retry_strategy: retryStrategy.rawValue,
+                                         ref_count: atomicVar.rawValue,
+                                         impl: retryStrategyPtr)
         let retryTokenPtr: UnsafeMutablePointer<aws_retry_token> = fromPointer(ptr: retryToken)
         self.rawValue = retryTokenPtr
     }

--- a/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryToken.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryToken.swift
@@ -7,17 +7,14 @@ public final class CRTAWSRetryToken {
     var rawValue: UnsafeMutablePointer<aws_retry_token>
 
     public init(retryStrategy: CRTRetryStrategy, allocator: Allocator = defaultAllocator) {
-        let intPointer = UnsafeMutablePointer<Int>.allocate(capacity: 1)
-        intPointer.pointee = 1
-        let atomicVar = aws_atomic_var(value: UnsafeMutableRawPointer(intPointer))
-        let retryStrategyPtr = UnsafeMutablePointer<CRTRetryStrategy>.allocate(capacity: 1)
-        retryStrategyPtr.initialize(to: retryStrategy)
+        let intPointer: UnsafeMutableRawPointer = fromPointer(ptr: 1)
+        let atomicVar = aws_atomic_var(value: intPointer)
+        let retryStrategyPtr: UnsafeMutablePointer<CRTRetryStrategy> = fromPointer(ptr: retryStrategy)
         let retryToken = aws_retry_token(allocator: allocator.rawValue,
                                         retry_strategy: retryStrategy.rawValue,
                                         ref_count: atomicVar,
                                         impl: retryStrategyPtr)
-        let retryTokenPtr = UnsafeMutablePointer<aws_retry_token>.allocate(capacity: 1)
-        retryTokenPtr.initialize(to: retryToken)
+        let retryTokenPtr: UnsafeMutablePointer<aws_retry_token> = fromPointer(ptr: retryToken)
         self.rawValue = retryTokenPtr
     }
 

--- a/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryToken.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryToken.swift
@@ -13,8 +13,7 @@ public final class CRTAWSRetryToken {
                                          retry_strategy: retryStrategy.rawValue,
                                          ref_count: atomicVar.rawValue,
                                          impl: retryStrategyPtr)
-        let retryTokenPtr: UnsafeMutablePointer<aws_retry_token> = fromPointer(ptr: retryToken)
-        self.rawValue = retryTokenPtr
+        self.rawValue = fromPointer(ptr: retryToken)
     }
 
     public init(rawValue: UnsafeMutablePointer<aws_retry_token>,

--- a/Source/AwsCommonRuntimeKit/io/retryer/CRTRetryStrategy.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/CRTRetryStrategy.swift
@@ -27,8 +27,7 @@ private func acquireRetryToken(_ retryStrategy: UnsafeMutablePointer<aws_retry_s
     }
 
     var tokenCallbackData = CRTAcquireTokenCallbackData(allocator: retryStrategySwift.pointee.allocator)
-    let callbackPointer = UnsafeMutablePointer<CRTAcquireTokenCallbackData>.allocate(capacity: 1)
-    callbackPointer.initialize(to: tokenCallbackData)
+    let callbackPointer: UnsafeMutablePointer<CRTAcquireTokenCallbackData> = fromPointer(ptr: tokenCallbackData)
     tokenCallbackData.onTokenAcquired = { (token, crtError) in
         if case let CRTError.crtError(error) = crtError {
             callbackFn?(retryStrategy, error.errorCode, token?.rawValue, callbackPointer)
@@ -52,8 +51,7 @@ private func scheduleRetry(_ token: UnsafeMutablePointer<aws_retry_token>?,
     }
 
     var scheduleCallbackData = CRTScheduleRetryCallbackData(allocator: retryStrategy.pointee.allocator)
-    let callbackPointer = UnsafeMutablePointer<CRTScheduleRetryCallbackData>.allocate(capacity: 1)
-    callbackPointer.initialize(to: scheduleCallbackData)
+    let callbackPointer: UnsafeMutablePointer<CRTScheduleRetryCallbackData> = fromPointer(ptr: scheduleCallbackData)
     scheduleCallbackData.onRetryReady = { (token, crtError) in
         if case let CRTError.crtError(error) = crtError {
             callbackFn?(token?.rawValue, error.errorCode, callbackPointer)
@@ -103,14 +101,11 @@ class WrappedCRTRetryStrategy {
                                                record_success: recordSuccess,
                                                release_token: releaseToken)
 
-        let intPointer = UnsafeMutablePointer<Int>.allocate(capacity: 1)
-        intPointer.pointee = 1
-        let atomicVar = aws_atomic_var(value: UnsafeMutableRawPointer(intPointer))
+        let intPointer: UnsafeMutableRawPointer = fromPointer(ptr: 1)
+        let atomicVar = aws_atomic_var(value: intPointer)
         self.allocator = allocator
-        let retryStategyPtr = UnsafeMutablePointer<CRTRetryStrategy>.allocate(capacity: 1)
-        retryStategyPtr.initialize(to: impl)
-        let vTablePtr = UnsafeMutablePointer<aws_retry_strategy_vtable>.allocate(capacity: 1)
-        vTablePtr.initialize(to: vtable)
+        let retryStategyPtr: UnsafeMutablePointer<CRTRetryStrategy> = fromPointer(ptr: impl)
+        let vTablePtr: UnsafeMutablePointer<aws_retry_strategy_vtable> = fromPointer(ptr: vtable)
         self.vTablePtr = vTablePtr
         self.implementationPtr = retryStategyPtr
         self.rawValue = aws_retry_strategy(allocator: allocator.rawValue,

--- a/Source/AwsCommonRuntimeKit/io/retryer/CRTRetryStrategy.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/CRTRetryStrategy.swift
@@ -103,14 +103,12 @@ class WrappedCRTRetryStrategy {
 
         let atomicVar = Atomic<Int>(1)
         self.allocator = allocator
-        let retryStategyPtr: UnsafeMutablePointer<CRTRetryStrategy> = fromPointer(ptr: impl)
-        let vTablePtr: UnsafeMutablePointer<aws_retry_strategy_vtable> = fromPointer(ptr: vtable)
-        self.vTablePtr = vTablePtr
-        self.implementationPtr = retryStategyPtr
+        self.vTablePtr = fromPointer(ptr: vtable)
+        self.implementationPtr = fromPointer(ptr: impl)
         self.rawValue = aws_retry_strategy(allocator: allocator.rawValue,
                                            vtable: vTablePtr,
                                            ref_count: atomicVar.rawValue,
-                                           impl: retryStategyPtr)
+                                           impl: implementationPtr)
     }
 
 }

--- a/Source/AwsCommonRuntimeKit/io/retryer/CRTRetryStrategy.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/CRTRetryStrategy.swift
@@ -47,8 +47,8 @@ private func scheduleRetry(_ token: UnsafeMutablePointer<aws_retry_token>?,
 
     guard let retryStrategy = userData?.assumingMemoryBound(to: CRTRetryStrategy.self),
           let token = token else {
-        return 1
-    }
+              return 1
+          }
 
     var scheduleCallbackData = CRTScheduleRetryCallbackData(allocator: retryStrategy.pointee.allocator)
     let callbackPointer: UnsafeMutablePointer<CRTScheduleRetryCallbackData> = fromPointer(ptr: scheduleCallbackData)
@@ -101,8 +101,7 @@ class WrappedCRTRetryStrategy {
                                                record_success: recordSuccess,
                                                release_token: releaseToken)
 
-        let intPointer: UnsafeMutableRawPointer = fromPointer(ptr: 1)
-        let atomicVar = aws_atomic_var(value: intPointer)
+        let atomicVar = Atomic<Int>(1)
         self.allocator = allocator
         let retryStategyPtr: UnsafeMutablePointer<CRTRetryStrategy> = fromPointer(ptr: impl)
         let vTablePtr: UnsafeMutablePointer<aws_retry_strategy_vtable> = fromPointer(ptr: vtable)
@@ -110,7 +109,7 @@ class WrappedCRTRetryStrategy {
         self.implementationPtr = retryStategyPtr
         self.rawValue = aws_retry_strategy(allocator: allocator.rawValue,
                                            vtable: vTablePtr,
-                                           ref_count: atomicVar,
+                                           ref_count: atomicVar.rawValue,
                                            impl: retryStategyPtr)
     }
 

--- a/Source/AwsCommonRuntimeKit/mqtt/MqttConnection.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/MqttConnection.swift
@@ -152,8 +152,7 @@ public class MqttConnection {
         mqttOptions.keep_alive_time_secs = UInt16(keepAliveTime)
         mqttOptions.ping_timeout_ms = UInt32(requestTimeoutMs)
         mqttOptions.clean_session = cleanSession
-        let connectionPtr: UnsafeMutableRawPointer = fromPointer(ptr: self)
-        mqttOptions.user_data = connectionPtr
+        mqttOptions.user_data = fromPointer(ptr: self)
 
         mqttOptions.on_connection_complete = { (connectionPtr,
                                                 errorCode,

--- a/Source/AwsCommonRuntimeKit/mqtt/MqttConnection.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/MqttConnection.swift
@@ -292,7 +292,7 @@ public class MqttConnection {
         let subAckCallbackData = SubAckCallbackData(onSubAck: onSubAck, connection: self, topic: nil)
         let subAckCallbackPtr: UnsafeMutablePointer<SubAckCallbackData> = fromPointer(ptr: subAckCallbackData)
         let topicPtr: UnsafeMutablePointer<aws_byte_cursor> = fromPointer(ptr: topicFilter.awsByteCursor)
-    
+
         let packetId = aws_mqtt_client_connection_subscribe(rawValue,
                                                             topicPtr,
                                                             qos.rawValue,
@@ -341,7 +341,7 @@ public class MqttConnection {
                                                          connection: self,
                                                          topics: topicFilters)
         let subAckCallbackPtr: UnsafeMutablePointer<MultiSubAckCallbackData> = fromPointer(ptr: subAckCallbackData)
- 
+
         var awsArray = aws_array_list()
         awsArray.current_size = topicFilters.count
         awsArray.item_size = MemoryLayout.size(ofValue: String.self)

--- a/Source/AwsCommonRuntimeKit/mqtt/MqttConnection.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/MqttConnection.swift
@@ -182,9 +182,9 @@ public class MqttConnection {
                 if aws_mqtt_client_connection_use_websockets(rawValue,
                                                              { (httpRequest, userData, completeFn, completeUserData) in
                     guard let userData = userData,
-                        let httpRequest = httpRequest else {
-                        return
-                    }
+                          let httpRequest = httpRequest else {
+                              return
+                          }
                     let ptr = userData.assumingMemoryBound(to: MqttConnection.self)
 
                     let onInterceptComplete: OnWebSocketHandshakeInterceptComplete = {request, crtError in
@@ -235,14 +235,14 @@ public class MqttConnection {
     /// - Returns: A `Bool` of True if the connection is open and is being shut down.
     func disconnect() -> Bool {
 
-       return aws_mqtt_client_connection_disconnect(rawValue, { (connectionPtr, userData) in
+        return aws_mqtt_client_connection_disconnect(rawValue, { (connectionPtr, userData) in
             guard let userData = userData else {
                 return
             }
             let connectionPtr = userData.assumingMemoryBound(to: MqttConnection.self)
             defer { connectionPtr.deinitializeAndDeallocate()}
 
-        connectionPtr.pointee.onDisconnect(connectionPtr.pointee.rawValue)
+            connectionPtr.pointee.onDisconnect(connectionPtr.pointee.rawValue)
         }, rawValue) == AWS_OP_SUCCESS
     }
 
@@ -300,8 +300,8 @@ public class MqttConnection {
             guard let userData = userData,
                   let topic = topicPtr?.pointee.toString(),
                   let payload = payload else {
-                return
-            }
+                      return
+                  }
             let ptr = userData.assumingMemoryBound(to: PubCallbackData.self)
             defer {
                 ptr.deinitializeAndDeallocate()
@@ -350,11 +350,11 @@ public class MqttConnection {
         let packetId = aws_mqtt_client_connection_subscribe_multiple(rawValue,
                                                                      &awsArray,
                                                                      { (_, packetId, topicPointers, errorCode, userData)
-                                                                        in
+            in
             guard let userData = userData,
                   let topicPointers = topicPointers else {
-                return
-            }
+                      return
+                  }
             let ptr = userData.assumingMemoryBound(to: MultiSubAckCallbackData.self)
             defer {ptr.deinitializeAndDeallocate()}
             var topics = [String]()
@@ -441,10 +441,8 @@ public class MqttConnection {
                                             CRTError.crtError(error))
         }, opCallbackPtr)
 
-        defer {
-            topicPointer.deinitializeAndDeallocate()
-            payloadPointer.deinitializeAndDeallocate()
-        }
+        topicPointer.deinitializeAndDeallocate()
+        payloadPointer.deinitializeAndDeallocate()
 
         return packetId
     }

--- a/Source/AwsCommonRuntimeKit/mqtt/MqttConnection.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/MqttConnection.swift
@@ -154,10 +154,8 @@ public class MqttConnection {
         mqttOptions.keep_alive_time_secs = UInt16(keepAliveTime)
         mqttOptions.ping_timeout_ms = UInt32(requestTimeoutMs)
         mqttOptions.clean_session = cleanSession
-        let connectionPtr = UnsafeMutablePointer<MqttConnection>.allocate(capacity: 1)
-        connectionPtr.initialize(to: self)
-        let ptr = UnsafeMutableRawPointer(connectionPtr)
-        mqttOptions.user_data = ptr
+        let connectionPtr: UnsafeMutableRawPointer = fromPointer(ptr: self)
+        mqttOptions.user_data = connectionPtr
 
         mqttOptions.on_connection_complete = { (connectionPtr,
                                                 errorCode,
@@ -293,13 +291,11 @@ public class MqttConnection {
                    onSubAck: @escaping OnSubAck) -> UInt16 {
 
         let pubCallbackData = PubCallbackData(onPublishReceived: onPublishReceived, mqttConnection: self)
-        let pubCallbackPtr = UnsafeMutablePointer<PubCallbackData>.allocate(capacity: 1)
-        pubCallbackPtr.initialize(to: pubCallbackData)
+        let pubCallbackPtr: UnsafeMutablePointer<PubCallbackData> = fromPointer(ptr: pubCallbackData)
         let subAckCallbackData = SubAckCallbackData(onSubAck: onSubAck, connection: self, topic: nil)
-        let subAckCallbackPtr = UnsafeMutablePointer<SubAckCallbackData>.allocate(capacity: 1)
-        subAckCallbackPtr.initialize(to: subAckCallbackData)
-        let topicPtr = UnsafeMutablePointer<aws_byte_cursor>.allocate(capacity: 1)
-        topicPtr.initialize(to: topicFilter.awsByteCursor)
+        let subAckCallbackPtr: UnsafeMutablePointer<SubAckCallbackData> = fromPointer(ptr: subAckCallbackData)
+        let topicPtr: UnsafeMutablePointer<aws_byte_cursor> = fromPointer(ptr: topicFilter.awsByteCursor)
+    
         let packetId = aws_mqtt_client_connection_subscribe(rawValue,
                                                             topicPtr,
                                                             qos.rawValue,
@@ -347,9 +343,8 @@ public class MqttConnection {
         let subAckCallbackData = MultiSubAckCallbackData(onMultiSubAck: onMultiSubAck,
                                                          connection: self,
                                                          topics: topicFilters)
-        let subAckCallbackPtr = UnsafeMutablePointer<MultiSubAckCallbackData>.allocate(capacity: 1)
-        subAckCallbackPtr.initialize(to: subAckCallbackData)
-
+        let subAckCallbackPtr: UnsafeMutablePointer<MultiSubAckCallbackData> = fromPointer(ptr: subAckCallbackData)
+ 
         let stringPointers = UnsafeMutablePointer<String>.allocate(capacity: topicFilters.count)
 
         for index in 0...topicFilters.count {
@@ -399,10 +394,8 @@ public class MqttConnection {
     /// - Returns: The packet id of the unsubscribe packet if successfully sent, otherwise 0.
     func unsubscribe(topicFilter: String, onComplete: @escaping OnOperationComplete) -> UInt16 {
         let opCallbackData = OpCompleteCallbackData(connection: self, onOperationComplete: onComplete)
-        let opCallbackPtr = UnsafeMutablePointer<OpCompleteCallbackData>.allocate(capacity: 1)
-        opCallbackPtr.initialize(to: opCallbackData)
-        let topicPtr = UnsafeMutablePointer<aws_byte_cursor>.allocate(capacity: 1)
-        topicPtr.initialize(to: topicFilter.awsByteCursor)
+        let opCallbackPtr: UnsafeMutablePointer<OpCompleteCallbackData> = fromPointer(ptr: opCallbackData)
+        let topicPtr: UnsafeMutablePointer<aws_byte_cursor> = fromPointer(ptr: topicFilter.awsByteCursor)
         let packetId = aws_mqtt_client_connection_unsubscribe(rawValue,
                                                               topicPtr,
                                                               { (_, packetId, errorCode, userData) in
@@ -438,8 +431,7 @@ public class MqttConnection {
         let opCallbackData = OpCompleteCallbackData(topic: topic,
                                                     connection: self,
                                                     onOperationComplete: onComplete)
-        let opCallbackPtr = UnsafeMutablePointer<OpCompleteCallbackData>.allocate(capacity: 1)
-        opCallbackPtr.initialize(to: opCallbackData)
+        let opCallbackPtr: UnsafeMutablePointer<OpCompleteCallbackData> = fromPointer(ptr: opCallbackData)
         let pointers = UnsafeMutablePointer<aws_byte_cursor>.allocate(capacity: 2)
         pointers.initialize(to: topic.awsByteCursor)
         pointers.advanced(by: 1).initialize(to: payload.awsByteCursor)


### PR DESCRIPTION
*Description of changes:* This PR refactors the way pointers are created and initialized in Swift to protect against cases where the pointer is created but uninitialized later causing a seg fault when the c code calls back into the Swift code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
