### PR TITLE
fix: m1 build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -66,6 +66,7 @@ awsCCommonPlatformExcludes.append("source/arch/intel")
 // unsafeFlagsArray.append("-mavx512f")
 #elseif arch(arm64)
 awsCCommonPlatformExcludes.append("source/arch/intel")
+awsCCommonPlatformExcludes.append("source/arch/generic")
 #else
 awsCCommonPlatformExcludes.append("source/arch/intel")
 awsCCommonPlatformExcludes.append("source/arch/arm")


### PR DESCRIPTION
*Description of changes:*
This PR adds an additional exclude needed in order to compile on m1 macs (arm). This closes a customer issue in the Swift SDK: https://github.com/awslabs/aws-sdk-swift/issues/392



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
