### PR TITLE
fix: make mqtt public

### DIFF
--- a/Source/AwsCommonRuntimeKit/mqtt/MqttClient.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/MqttClient.swift
@@ -26,11 +26,11 @@ public final class MqttClient {
     ///   - allocator: The allocator instance to allocate memory on
     /// - Returns: `MqttConnection`
     public func newConnection(host: String,
-                       port: Int16,
-                       socketOptions: SocketOptions,
-                       tlsContext: TlsContext,
-                       useWebSockets: Bool,
-                       allocator: Allocator) -> MqttConnection {
+                              port: Int16,
+                              socketOptions: SocketOptions,
+                              tlsContext: TlsContext,
+                              useWebSockets: Bool,
+                              allocator: Allocator) -> MqttConnection {
         return MqttConnection(clientPointer: rawValue,
                               host: host,
                               port: port,
@@ -49,10 +49,10 @@ public final class MqttClient {
     ///   - allocator: The allocator instance to allocate memory on
     /// - Returns: `MqttConnection`
     public func newConnection(host: String,
-                       port: Int16,
-                       socketOptions: SocketOptions,
-                       useWebSockets: Bool,
-                       allocator: Allocator) -> MqttConnection {
+                              port: Int16,
+                              socketOptions: SocketOptions,
+                              useWebSockets: Bool,
+                              allocator: Allocator) -> MqttConnection {
         return MqttConnection(clientPointer: rawValue,
                               host: host,
                               port: port,


### PR DESCRIPTION
*Description of changes:*
Can't consume from ios device unless public.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
