### PR TITLE
fix: add host address struct to copy over fields from c

### DIFF
--- a/Source/AwsCommonRuntimeKit/io/AddressRecordType.swift
+++ b/Source/AwsCommonRuntimeKit/io/AddressRecordType.swift
@@ -1,0 +1,23 @@
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0.
+
+import AwsCIo
+
+public enum AddressRecordType {
+    case typeA
+    case typeAAAA
+}
+
+extension AddressRecordType: RawRepresentable, CaseIterable {
+
+    public init(rawValue: aws_address_record_type) {
+        let value = Self.allCases.first { $0.rawValue == rawValue }
+        self = value ?? .typeA
+    }
+    public var rawValue: aws_address_record_type {
+        switch self {
+        case .typeA:  return aws_address_record_type(rawValue: 0)
+        case .typeAAAA:  return aws_address_record_type(rawValue: 1)
+        }
+    }
+}

--- a/Source/AwsCommonRuntimeKit/io/HostAddress.swift
+++ b/Source/AwsCommonRuntimeKit/io/HostAddress.swift
@@ -1,0 +1,35 @@
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0.
+
+import AwsCIo
+
+public struct HostAddress {
+    let host: String?
+    let address: String?
+    let recordType: AddressRecordType
+    let expiry: UInt64
+    let useCount: Int
+    let connectionFailureCount: Int
+    let weight: UInt8
+    
+    init(hostAddress: aws_host_address) {
+        self.host = String(awsString: hostAddress.host)
+        self.address = String(awsString: hostAddress.address)
+        self.recordType = AddressRecordType(rawValue: hostAddress.record_type)
+        self.expiry = hostAddress.expiry
+        self.useCount = hostAddress.use_count
+        self.connectionFailureCount = hostAddress.connection_failure_count
+        self.weight = hostAddress.weight
+    }
+    
+    init() {
+        self.host = nil
+        self.address = nil
+        self.recordType = .typeA
+        self.expiry = 0
+        self.useCount = 0
+        self.connectionFailureCount = 0
+        self.weight = 0
+    }
+}
+

--- a/Source/AwsCommonRuntimeKit/io/HostAddress.swift
+++ b/Source/AwsCommonRuntimeKit/io/HostAddress.swift
@@ -11,7 +11,7 @@ public struct HostAddress {
     let useCount: Int
     let connectionFailureCount: Int
     let weight: UInt8
-    
+
     init(hostAddress: aws_host_address) {
         self.host = String(awsString: hostAddress.host)
         self.address = String(awsString: hostAddress.address)
@@ -21,7 +21,7 @@ public struct HostAddress {
         self.connectionFailureCount = hostAddress.connection_failure_count
         self.weight = hostAddress.weight
     }
-    
+
     init() {
         self.host = nil
         self.address = nil
@@ -32,4 +32,3 @@ public struct HostAddress {
         self.weight = 0
     }
 }
-

--- a/Source/AwsCommonRuntimeKit/io/HostResolver.swift
+++ b/Source/AwsCommonRuntimeKit/io/HostResolver.swift
@@ -4,7 +4,6 @@
 import AwsCCommon
 import AwsCIo
 
-public typealias HostAddress = aws_host_address
 public typealias HostResolvedContinuation = CheckedContinuation<[HostAddress], Error>
 
 public protocol HostResolver: AnyObject {
@@ -86,10 +85,12 @@ private func onHostResolved(_ resolver: UnsafeMutablePointer<aws_host_resolver>!
     let length = aws_array_list_length(hostAddresses)
     var addresses: [HostAddress] = Array(repeating: HostAddress(), count: length)
 
-    for index  in 0..<length {
+    for index in 0..<length {
         var address: UnsafeMutableRawPointer! = nil
         aws_array_list_get_at_ptr(hostAddresses, &address, index)
-        addresses[index] = address.bindMemory(to: HostAddress.self, capacity: 1).pointee
+        let hostAddressCType = address.bindMemory(to: aws_host_address.self, capacity: 1).pointee
+        let hostAddress = HostAddress(hostAddress: hostAddressCType)
+        addresses[index] = hostAddress
     }
 
     if errorCode == 0 {


### PR DESCRIPTION
*Description of changes:* This PR adds a new swift type that copies over the host address fields in order to hold onto them since c lets them go at an indeterminate time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
