### PR TITLE
Pass the continuation for scheduling retries. Fix variable name.

### DIFF
--- a/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CRTAWSCredentialsProvider.swift
@@ -92,7 +92,7 @@ public final class CRTAWSCredentialsProvider {
             profileOptionsC.credentials_file_name_override = credentialsFileName.awsByteCursor
         }
 
-        if let profileName = profileOptions.profileFileNameOverride {
+        if let profileName = profileOptions.profileNameOverride {
             profileOptionsC.profile_name_override = profileName.awsByteCursor
         }
         profileOptionsC.shutdown_options = CRTAWSCredentialsProvider.setUpShutDownOptions(shutDownOptions: profileOptions.shutdownOptions)

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CRTCredentialsProviderProfileOptions.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CRTCredentialsProviderProfileOptions.swift
@@ -4,6 +4,6 @@
 public protocol CRTCredentialsProviderProfileOptions {
     var shutdownOptions: CRTCredentialsProviderShutdownOptions? {get set}
     var configFileNameOverride: String? {get set}
-    var profileFileNameOverride: String? {get set}
+    var profileNameOverride: String? {get set}
     var credentialsFileNameOverride: String? {get set}
 }

--- a/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryStrategy.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryStrategy.swift
@@ -72,7 +72,7 @@ public final class CRTAWSRetryStrategy {
     }
 
     private func scheduleRetryToCRT(token: CRTAWSRetryToken, errorType: CRTRetryError, continuation: ScheduleRetryContinuation) {
-        let callbackData = CRTScheduleRetryCallbackData(allocator: allocator)
+        let callbackData = CRTScheduleRetryCallbackData(allocator: allocator, continuation: continuation)
         let pointer: UnsafeMutablePointer<CRTScheduleRetryCallbackData> = fromPointer(ptr: callbackData)
 
         aws_retry_strategy_schedule_retry(token.rawValue, errorType.rawValue, { retryToken, errorCode, userdata in

--- a/Test/AwsCommonRuntimeKitTests/auth/AWSCredentialsProviderTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/auth/AWSCredentialsProviderTests.swift
@@ -218,16 +218,16 @@ struct MockCredentialsProviderProfileOptions: CRTCredentialsProviderProfileOptio
     
     var configFileNameOverride: String?
     
-    var profileFileNameOverride: String?
+    var profileNameOverride: String?
     
     var credentialsFileNameOverride: String?
     
     init(configFileNameOverride: String? = nil,
-         profileFileNameOverride: String? = nil,
+         profileNameOverride: String? = nil,
          credentialsFileNameOverride: String? = nil,
          shutdownOptions: CRTCredentialsProviderShutdownOptions? = nil) {
         self.configFileNameOverride = configFileNameOverride
-        self.profileFileNameOverride = profileFileNameOverride
+        self.profileNameOverride = profileNameOverride
         self.credentialsFileNameOverride = credentialsFileNameOverride
         self.shutdownOptions = shutdownOptions
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Change the property name `profileFileNameOverride` to `profileFileNameOverride` to accurately reflect its purpose.
2. Pass the continuation for scheduling retries so the continuation is handled properly and retries can occur.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
