### PR TITLE
removes redundant call to aws_retry_token_release

### DIFF
--- a/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryStrategy.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryStrategy.swift
@@ -97,8 +97,8 @@ public final class CRTAWSRetryStrategy {
         aws_retry_token_record_success(token.rawValue)
     }
 
+    @available(*, deprecated, message: "This function will be removed soon.")
     public func releaseToken(token: CRTAWSRetryToken) {
-        aws_retry_token_release(token.rawValue)
     }
 
     deinit {

--- a/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryToken.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryToken.swift
@@ -11,7 +11,4 @@ public final class CRTAWSRetryToken {
         self.rawValue = rawValue
     }
 
-    deinit {
-        aws_retry_token_release(rawValue)
-    }
 }

--- a/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryToken.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/CRTAWSRetryToken.swift
@@ -11,4 +11,8 @@ public final class CRTAWSRetryToken {
         self.rawValue = rawValue
     }
 
+    deinit {
+        aws_retry_token_release(rawValue)
+    }
+
 }


### PR DESCRIPTION
*Issue #, if available:*

#66

*Description of changes:*

Identified a redundant memory release call and removed it. See issue for details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
