### PR TITLE
handles errors for HttpStream

### DIFF
--- a/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
@@ -31,7 +31,7 @@ public class HttpClientConnection {
     /// - Parameter requestOptions: An `HttpRequestOptions` struct containing callbacks on
     /// the different events from the stream
     /// - Returns: An `HttpStream` containing the `HttpClientConnection`
-    public func makeRequest(requestOptions: HttpRequestOptions) -> HttpStream {
+    public func makeRequest(requestOptions: HttpRequestOptions) throws -> HttpStream {
         var options = aws_http_make_request_options()
         options.self_size = MemoryLayout<aws_http_make_request_options>.size
         options.request = requestOptions.request.rawValue
@@ -115,7 +115,9 @@ public class HttpClientConnection {
         let stream = HttpStream(httpConnection: self)
         cbData.stream = stream
         stream.httpStream = aws_http_connection_make_request(rawValue, &options)
-
+        if stream.httpStream == nil {
+            throw AWSCommonRuntimeError()
+        }
         return stream
     }
 

--- a/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpClientConnection.swift
@@ -114,10 +114,10 @@ public class HttpClientConnection {
 
         let stream = HttpStream(httpConnection: self)
         cbData.stream = stream
-        stream.httpStream = aws_http_connection_make_request(rawValue, &options)
-        if stream.httpStream == nil {
+        guard let httpStream = aws_http_connection_make_request(rawValue, &options) else {
             throw AWSCommonRuntimeError()
         }
+        stream.httpStream = httpStream
         return stream
     }
 

--- a/Source/AwsCommonRuntimeKit/http/HttpClientConnectionOptions.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpClientConnectionOptions.swift
@@ -55,7 +55,6 @@ public struct HttpClientConnectionOptions {
                 enableManualWindowManagement: Bool = false,
                 maxConnectionIdleMs: UInt64 = 0,
                 shutDownOptions: ShutDownCallbackOptions? = nil) {
-
         self.clientBootstrap = bootstrap
         self.hostName = hostName
         self.initialWindowSize = initialWindowSize

--- a/Source/AwsCommonRuntimeKit/http/HttpStream.swift
+++ b/Source/AwsCommonRuntimeKit/http/HttpStream.swift
@@ -26,15 +26,20 @@ public class HttpStream {
     /// - Parameters:
     ///   - incrementBy:  How many bytes to increment the sliding window by.
     public func updateWindow(incrementBy: Int) {
+        assert(httpStream != nil)
         aws_http_stream_update_window(httpStream, incrementBy)
     }
 
     ///Activates the client stream.
-    public func activate() {
-        aws_http_stream_activate(httpStream)
+    public func activate() throws {
+        assert(httpStream != nil)
+        if aws_http_stream_activate(httpStream) != AWS_OP_SUCCESS {
+            throw AWSCommonRuntimeError()
+        }
     }
 
     deinit {
+        assert(httpStream != nil)
         aws_http_stream_release(httpStream)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

#69

*Description of changes:*

The status code was not being used to check if there was a failure. This update now checks and throws and error if there is one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
