### PR TITLE
fix!: Rename package to match name inferred from git URL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let excludesFromAll = ["tests", "cmake", "CONTRIBUTING.md",
                         "CMakeLists.txt", "README.md"]
 var packageTargets: [Target] = []
 
-var package = Package(name: "AwsCrt",
+var package = Package(name: "aws-crt-swift",
                       platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
                       products: [
                         .library(name: "AwsCommonRuntimeKit", targets: ["AwsCommonRuntimeKit"]),


### PR DESCRIPTION
*Issue #*
Fixes https://github.com/awslabs/aws-sdk-swift/issues/680

*Description of changes:*

Change the declared name of this package to match its inferred name (i.e. the last path component of its Git URL, minus the extension).  This is being performed in conjunction with similar renames of `aws-sdk-swift` and `smithy-swift`.  A complete rationale for making this change is given in [this PR](https://github.com/awslabs/aws-sdk-swift/pull/678).

**This is a breaking change** but consumers of this package simply need to update their `Package.swift` to refer to the package by the new name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
