### PR TITLE
Fix input stream

### DIFF
--- a/Source/AwsCommonRuntimeKit/event-stream/EventStreamHeader.swift
+++ b/Source/AwsCommonRuntimeKit/event-stream/EventStreamHeader.swift
@@ -15,6 +15,11 @@ public struct EventStreamHeader {
 
     /// value.count can not be greater than EventStreamHeader.maxValueLength for supported types.
     public var value: EventStreamHeaderValue
+
+    public init(name: String, value: EventStreamHeaderValue) {
+        self.name = name
+        self.value = value
+    }
 }
 
 public enum EventStreamHeaderValue: Equatable {

--- a/Source/AwsCommonRuntimeKit/event-stream/EventStreamMessage.swift
+++ b/Source/AwsCommonRuntimeKit/event-stream/EventStreamMessage.swift
@@ -9,6 +9,14 @@ public struct EventStreamMessage {
     var payload: Data = Data()
     var allocator: Allocator = defaultAllocator
 
+    public init(headers: [EventStreamHeader] = [EventStreamHeader](),
+                payload: Data = Data(),
+                allocator: Allocator = defaultAllocator) {
+        self.headers = headers
+        self.payload = payload
+        self.allocator = allocator
+    }
+
     /// Get the binary format of this message (i.e. for sending across the wire manually)
     /// - Returns:  binary Data.
     public func getEncoded() throws -> Data {

--- a/Source/AwsCommonRuntimeKit/http/HTTPMessage.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPMessage.swift
@@ -11,7 +11,7 @@ public class HTTPMessage {
         willSet(value) {
             if let newBody = value {
                 let iStreamCore = IStreamCore(iStreamable: newBody, allocator: allocator)
-                aws_http_message_set_body_stream(self.rawValue, &iStreamCore.rawValue)
+                aws_http_message_set_body_stream(self.rawValue, iStreamCore.rawValue)
             } else {
                 aws_http_message_set_body_stream(self.rawValue, nil)
             }

--- a/Source/AwsCommonRuntimeKit/http/HTTPRequest.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPRequest.swift
@@ -52,7 +52,7 @@ public class HTTPRequest: HTTPMessage {
 
         if let body = body {
             let iStreamCore = IStreamCore(iStreamable: body, allocator: allocator)
-            aws_http_message_set_body_stream(self.rawValue, &iStreamCore.rawValue)
+            aws_http_message_set_body_stream(self.rawValue, iStreamCore.rawValue)
         }
         addHeaders(headers: headers)
     }

--- a/Source/AwsCommonRuntimeKit/io/StreamCore.swift
+++ b/Source/AwsCommonRuntimeKit/io/StreamCore.swift
@@ -6,7 +6,7 @@ import AwsCCommon
 
 /// aws_input_stream has acquire and release functions which manage the lifetime of this object.
 class IStreamCore {
-    var rawValue: aws_input_stream
+    var rawValue: UnsafeMutablePointer<aws_input_stream>
     let iStreamable: IStreamable
     var isEndOfStream: Bool = false
     private let allocator: Allocator
@@ -23,16 +23,17 @@ class IStreamCore {
     init(iStreamable: IStreamable, allocator: Allocator) {
         self.allocator = allocator
         self.iStreamable = iStreamable
-        rawValue = aws_input_stream()
+        rawValue = allocator.allocate(capacity: 1)
         // Use a manually managed vtable pointer to avoid undefined behavior
         self.vtablePointer = allocator.allocate(capacity: 1)
         vtablePointer.initialize(to: vtable)
-        rawValue.vtable = UnsafePointer(vtablePointer)
+        rawValue.pointee.vtable = UnsafePointer(vtablePointer)
 
-        rawValue.impl = Unmanaged<IStreamCore>.passUnretained(self).toOpaque()
+        rawValue.pointee.impl = Unmanaged<IStreamCore>.passUnretained(self).toOpaque()
     }
 
     deinit {
+        allocator.release(rawValue)
         allocator.release(vtablePointer)
     }
 }


### PR DESCRIPTION
*Description of changes:*
- C APIs store a pointer to input stream. Use an actual pointer to fix undefined behavior as storing pointers generated by & is not valid.
-  Adds public struct initializers because auto generated struct initializers have an internal scope.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
