### PR TITLE
Remove HTTPStream from HTTP callbacks

### DIFF
--- a/Source/AwsCommonRuntimeKit/http/HTTP2Stream.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTP2Stream.swift
@@ -26,9 +26,6 @@ public class HTTP2Stream: HTTPStream {
                   callbackData: HTTPStreamCallbackCore) {
         httpConnection = nil
         super.init(rawValue: rawValue, callbackData: callbackData)
-        callbackData.stream = self
-        // HTTP2Stream is pre-activated in C
-        activated = true
     }
 
     /// Reset the HTTP/2 stream (HTTP/2 only).

--- a/Source/AwsCommonRuntimeKit/http/HTTPHeaderBlock.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPHeaderBlock.swift
@@ -2,8 +2,7 @@
 //  SPDX-License-Identifier: Apache-2.0.
 import AwsCHttp
 
-public enum HTTPHeaderBlock {
-
+enum HTTPHeaderBlock {
     /// Main header block sent with request or response.
     case main
     /// Header block for 1xx informational (interim) responses.
@@ -14,12 +13,12 @@ public enum HTTPHeaderBlock {
 
 extension HTTPHeaderBlock: RawRepresentable, CaseIterable {
 
-    public init(rawValue: aws_http_header_block) {
+    init(rawValue: aws_http_header_block) {
         let value = Self.allCases.first(where: {$0.rawValue == rawValue})
         self = value ?? .main
     }
 
-    public var rawValue: aws_http_header_block {
+    var rawValue: aws_http_header_block {
         switch self {
         case .main: return AWS_HTTP_HEADER_BLOCK_MAIN
         case .informational: return AWS_HTTP_HEADER_BLOCK_INFORMATIONAL

--- a/Source/AwsCommonRuntimeKit/http/HTTPRequestOptions.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPRequestOptions.swift
@@ -2,30 +2,36 @@
 //  SPDX-License-Identifier: Apache-2.0.
 import Foundation
 
+/// Definition for outgoing request and callbacks to receive response.
 public struct HTTPRequestOptions {
 
-    public typealias OnInterimResponse = (_ statusCode: Int32,
+    /// Callback to receive interim response
+    public typealias OnInterimResponse = (_ statusCode: UInt32,
                                           _ headers: [HTTPHeader]) -> Void
-    public typealias OnResponse = (_ statusCode: Int32,
+    /// Callback to receive main headers
+    public typealias OnResponse = (_ statusCode: UInt32,
                                    _ headers: [HTTPHeader]) -> Void
-    public typealias OnTrailer = (_ headers: [HTTPHeader]) -> Void
+    /// Callback to receive the incoming body
     public typealias OnIncomingBody = (_ bodyChunk: Data) -> Void
-    public typealias OnStreamComplete = (_ result: Result<Int32, CommonRunTimeError>) -> Void
+    /// Callback to receive trailer headers
+    public typealias OnTrailer = (_ headers: [HTTPHeader]) -> Void
+    /// Callback to know when request is completed, whether successful or unsuccessful
+    public typealias OnStreamComplete = (_ result: Result<UInt32, CommonRunTimeError>) -> Void
 
     /// Outgoing request.
     let request: HTTPRequestBase
 
-    /// Invoked when informational 1xx interim response is received
+    /// Invoked 0+ times if informational 1xx interim responses are received.
     public let onInterimResponse: OnInterimResponse?
 
     /// Invoked when main response headers are received.
     public let onResponse: OnResponse
 
-    /// Invoked when trailer response is received.
-    public let onTrailer: OnTrailer?
-
     /// Invoked repeatedly as body data is received.
     public let onIncomingBody: OnIncomingBody
+
+    /// Invoked when trailer headers are received.
+    public let onTrailer: OnTrailer?
 
     /// Invoked when request/response stream is complete, whether successful or unsuccessful
     public let onStreamComplete: OnStreamComplete
@@ -33,12 +39,12 @@ public struct HTTPRequestOptions {
     /// When using HTTP/2, set http2ManualDataWrites to true to specify that request body data will be provided over time.
     /// The stream will only be polled for writing when data has been supplied via `HTTP2Stream.writeData`
     public var http2ManualDataWrites: Bool = false
-
+    
     public init(request: HTTPRequestBase,
                 onInterimResponse: OnInterimResponse? = nil,
                 onResponse: @escaping OnResponse,
-                onTrailer: OnTrailer? = nil,
                 onIncomingBody: @escaping OnIncomingBody,
+                onTrailer: OnTrailer? = nil,
                 onStreamComplete: @escaping OnStreamComplete,
                 http2ManualDataWrites: Bool = false) {
         self.request = request

--- a/Source/AwsCommonRuntimeKit/http/HTTPRequestOptions.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPRequestOptions.swift
@@ -3,6 +3,14 @@
 import Foundation
 
 public struct HTTPRequestOptions {
+
+    public typealias OnInterimResponse = (_ statusCode: Int32,
+                                          _ headers: [HTTPHeader]) -> Void
+
+    public typealias OnResponse = (_ statusCode: Int32,
+                                   _ headers: [HTTPHeader]) -> Void
+    public typealias OnTrailer = (_ headers: [HTTPHeader]) -> Void
+
     public typealias OnIncomingHeaders = (_ statusCode: Int32,
                                           _ headerBlock: HTTPHeaderBlock,
                                           _ headers: [HTTPHeader]) -> Void
@@ -13,11 +21,14 @@ public struct HTTPRequestOptions {
     /// Outgoing request.
     let request: HTTPRequestBase
 
-    /// Invoked repeatedly as headers are received.
-    public let onIncomingHeaders: OnIncomingHeaders
+    /// Invoked when informational 1xx interim response is received
+    public let onInterimResponse: OnInterimResponse?
 
-    /// Invoked when response header block has been completely read.
-    public let onIncomingHeadersBlockDone: OnIncomingHeadersBlockDone
+    /// Invoked when main response headers are received.
+    public let onResponse: OnResponse
+
+    /// Invoked when trailer response headers are received.
+    public let onTrailer: OnTrailer?
 
     /// Invoked repeatedly as body data is received.
     public let onIncomingBody: OnIncomingBody
@@ -30,14 +41,16 @@ public struct HTTPRequestOptions {
     public var http2ManualDataWrites: Bool = false
 
     public init(request: HTTPRequestBase,
-                onIncomingHeaders: @escaping OnIncomingHeaders,
-                onIncomingHeadersBlockDone: @escaping OnIncomingHeadersBlockDone,
+                onInterimResponse: OnInterimResponse? = nil,
+                onResponse: @escaping OnResponse,
+                onTrailer: OnTrailer? = nil,
                 onIncomingBody: @escaping OnIncomingBody,
                 onStreamComplete: @escaping OnStreamComplete,
                 http2ManualDataWrites: Bool = false) {
         self.request = request
-        self.onIncomingHeaders = onIncomingHeaders
-        self.onIncomingHeadersBlockDone = onIncomingHeadersBlockDone
+        self.onInterimResponse = onInterimResponse
+        self.onResponse = onResponse
+        self.onTrailer = onTrailer
         self.onIncomingBody = onIncomingBody
         self.onStreamComplete = onStreamComplete
         self.http2ManualDataWrites = http2ManualDataWrites

--- a/Source/AwsCommonRuntimeKit/http/HTTPRequestOptions.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPRequestOptions.swift
@@ -21,7 +21,7 @@ public struct HTTPRequestOptions {
     /// Invoked when main response headers are received.
     public let onResponse: OnResponse
 
-    /// Invoked when trailer response headers are received.
+    /// Invoked when trailer response is received.
     public let onTrailer: OnTrailer?
 
     /// Invoked repeatedly as body data is received.

--- a/Source/AwsCommonRuntimeKit/http/HTTPRequestOptions.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPRequestOptions.swift
@@ -3,13 +3,12 @@
 import Foundation
 
 public struct HTTPRequestOptions {
-    public typealias OnIncomingHeaders = (_ stream: HTTPStream,
+    public typealias OnIncomingHeaders = (_ statusCode: Int32,
                                           _ headerBlock: HTTPHeaderBlock,
                                           _ headers: [HTTPHeader]) -> Void
-    public typealias OnIncomingHeadersBlockDone = (_ stream: HTTPStream,
-                                                   _ headerBlock: HTTPHeaderBlock) -> Void
-    public typealias OnIncomingBody = (_ stream: HTTPStream, _ bodyChunk: Data) -> Void
-    public typealias OnStreamComplete = (_ stream: HTTPStream, _ error: CRTError?) -> Void
+    public typealias OnIncomingHeadersBlockDone = (_ headerBlock: HTTPHeaderBlock) -> Void
+    public typealias OnIncomingBody = (_ bodyChunk: Data) -> Void
+    public typealias OnStreamComplete = (_ result: Result<Int32, CommonRunTimeError>) -> Void
 
     /// Outgoing request.
     let request: HTTPRequestBase

--- a/Source/AwsCommonRuntimeKit/http/HTTPRequestOptions.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPRequestOptions.swift
@@ -6,15 +6,9 @@ public struct HTTPRequestOptions {
 
     public typealias OnInterimResponse = (_ statusCode: Int32,
                                           _ headers: [HTTPHeader]) -> Void
-
     public typealias OnResponse = (_ statusCode: Int32,
                                    _ headers: [HTTPHeader]) -> Void
     public typealias OnTrailer = (_ headers: [HTTPHeader]) -> Void
-
-    public typealias OnIncomingHeaders = (_ statusCode: Int32,
-                                          _ headerBlock: HTTPHeaderBlock,
-                                          _ headers: [HTTPHeader]) -> Void
-    public typealias OnIncomingHeadersBlockDone = (_ headerBlock: HTTPHeaderBlock) -> Void
     public typealias OnIncomingBody = (_ bodyChunk: Data) -> Void
     public typealias OnStreamComplete = (_ result: Result<Int32, CommonRunTimeError>) -> Void
 

--- a/Source/AwsCommonRuntimeKit/http/HTTPStream.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPStream.swift
@@ -8,8 +8,6 @@ import Foundation
 public class HTTPStream {
     let rawValue: UnsafeMutablePointer<aws_http_stream>
     var callbackData: HTTPStreamCallbackCore
-    var activated: Bool = false
-    let lock = NSLock()
 
     init(rawValue: UnsafeMutablePointer<aws_http_stream>,
          callbackData: HTTPStreamCallbackCore) {
@@ -39,20 +37,9 @@ public class HTTPStream {
 
     /// Activates the client stream.
     public func activate() throws {
-        lock.lock()
-        defer {
-            lock.unlock()
-        }
-        guard !activated else {
-            return
-        }
-
-        callbackData.stream = self
         if aws_http_stream_activate(rawValue) != AWS_OP_SUCCESS {
-            callbackData.stream = nil
             throw CommonRunTimeError.crtError(.makeFromLastError())
         }
-        activated = true
     }
 
     deinit {

--- a/Source/AwsCommonRuntimeKit/http/HTTPStreamCallbackCore.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPStreamCallbackCore.swift
@@ -55,7 +55,12 @@ private func onResponseHeaders(stream: UnsafeMutablePointer<aws_http_stream>?,
         count: headersCount).map { HTTPHeader(rawValue: $0) }
     var status: Int32 = 0
     guard aws_http_stream_get_incoming_response_status(stream!, &status) == AWS_OP_SUCCESS else {
-        fatalError("Failed to get HTTP status code in onResponseHeaders callback with error \(CommonRunTimeError.crtError(.makeFromLastError()))")
+        fatalError(
+            """
+            Failed to get HTTP status code in onResponseHeaders callback with error
+            \(CommonRunTimeError.crtError(.makeFromLastError()))
+            """
+        )
     }
     httpStreamCbData.requestOptions.onIncomingHeaders(status,
                                                       HTTPHeaderBlock(rawValue: headerBlock),
@@ -99,7 +104,12 @@ private func onComplete(stream: UnsafeMutablePointer<aws_http_stream>?,
 
     var status: Int32 = 0
     guard aws_http_stream_get_incoming_response_status(stream!, &status) == AWS_OP_SUCCESS else {
-        fatalError("Failed to get HTTP status code in onComplete callback with error \(CommonRunTimeError.crtError(.makeFromLastError()))")
+        fatalError(
+            """
+            Failed to get HTTP status code in onComplete callback with error
+            \(CommonRunTimeError.crtError(.makeFromLastError()))
+            """
+        )
     }
     onStreamCompleteFn(.success(status))
 }

--- a/Source/AwsCommonRuntimeKit/http/HTTPStreamCallbackCore.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPStreamCallbackCore.swift
@@ -72,9 +72,9 @@ private func onResponseHeaderBlockDone(stream: UnsafeMutablePointer<aws_http_str
     }
     switch HTTPHeaderBlock(rawValue: headerBlock) {
     case .informational:
-        httpStreamCbData.requestOptions.onInterimResponse?(status, httpStreamCbData.headers)
+        httpStreamCbData.requestOptions.onInterimResponse?(UInt32(status), httpStreamCbData.headers)
     case .main:
-        httpStreamCbData.requestOptions.onResponse(status, httpStreamCbData.headers)
+        httpStreamCbData.requestOptions.onResponse(UInt32(status), httpStreamCbData.headers)
     case .trailing:
         httpStreamCbData.requestOptions.onTrailer?(httpStreamCbData.headers)
     }
@@ -118,7 +118,7 @@ private func onComplete(stream: UnsafeMutablePointer<aws_http_stream>?,
             """
         )
     }
-    onStreamCompleteFn(.success(status))
+    onStreamCompleteFn(.success(UInt32(status)))
 }
 
 private func onDestroy(userData: UnsafeMutableRawPointer!) {

--- a/Source/Elasticurl/Elasticurl.swift
+++ b/Source/Elasticurl/Elasticurl.swift
@@ -280,7 +280,7 @@ struct Elasticurl {
             }
             httpRequest.addHeaders(headers: headers)
 
-            let onResponse: HTTPRequestOptions.OnResponse = { status, headers in
+            let onResponse: HTTPRequestOptions.OnResponse = { _, headers in
                 for header in headers {
                     print(header.name + " : " + header.value)
                 }

--- a/Source/Elasticurl/Elasticurl.swift
+++ b/Source/Elasticurl/Elasticurl.swift
@@ -280,7 +280,7 @@ struct Elasticurl {
             }
             httpRequest.addHeaders(headers: headers)
 
-            let onIncomingHeaders: HTTPRequestOptions.OnIncomingHeaders = { _, _, headers in
+            let onResponse: HTTPRequestOptions.OnResponse = { status, headers in
                 for header in headers {
                     print(header.name + " : " + header.value)
                 }
@@ -288,10 +288,6 @@ struct Elasticurl {
 
             let onBody: HTTPRequestOptions.OnIncomingBody = { bodyChunk in
                 writeData(data: bodyChunk)
-            }
-
-            let onBlockDone: HTTPRequestOptions.OnIncomingHeadersBlockDone = { _ in
-
             }
 
             let onComplete: HTTPRequestOptions.OnStreamComplete = { result in
@@ -313,8 +309,7 @@ struct Elasticurl {
             do {
                 let connection = try await connectionManager.acquireConnection()
                 let requestOptions = HTTPRequestOptions(request: httpRequest,
-                                                        onIncomingHeaders: onIncomingHeaders,
-                                                        onIncomingHeadersBlockDone: onBlockDone,
+                                                        onResponse: onResponse,
                                                         onIncomingBody: onBody,
                                                         onStreamComplete: onComplete)
                 stream = try connection.makeRequest(requestOptions: requestOptions)

--- a/Source/Elasticurl/Elasticurl.swift
+++ b/Source/Elasticurl/Elasticurl.swift
@@ -286,16 +286,16 @@ struct Elasticurl {
                 }
             }
 
-            let onBody: HTTPRequestOptions.OnIncomingBody = { _, bodyChunk in
+            let onBody: HTTPRequestOptions.OnIncomingBody = { bodyChunk in
                 writeData(data: bodyChunk)
             }
 
-            let onBlockDone: HTTPRequestOptions.OnIncomingHeadersBlockDone = { _, _ in
+            let onBlockDone: HTTPRequestOptions.OnIncomingHeadersBlockDone = { _ in
 
             }
 
-            let onComplete: HTTPRequestOptions.OnStreamComplete = { _, error in
-                print(error?.message ?? "Success")
+            let onComplete: HTTPRequestOptions.OnStreamComplete = { result in
+                print(result)
 
                 semaphore.signal()
             }

--- a/Test/AwsCommonRuntimeKitTests/http/HTTP2ClientConnectionTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/http/HTTP2ClientConnectionTests.swift
@@ -148,7 +148,7 @@ class HTTP2ClientConnectionTests: HTTPClientTestFixture {
                 body: testBody,
                 response: &httpResponse,
                 semaphore: semaphore,
-                onComplete: { stream, error in
+                onComplete: { _ in
                     onCompleteCalled = true
                 },
                 http2ManualDataWrites: true)

--- a/Test/AwsCommonRuntimeKitTests/http/HTTPClientTestFixture.swift
+++ b/Test/AwsCommonRuntimeKitTests/http/HTTPClientTestFixture.swift
@@ -28,9 +28,8 @@ class HTTPClientTestFixture: XCBaseTestCase {
                          expectedVersion: HTTPVersion = HTTPVersion.version_1_1,
                          requestVersion: HTTPVersion = HTTPVersion.version_1_1,
                          numRetries: UInt = 2,
-                         onIncomingHeaders: HTTPRequestOptions.OnIncomingHeaders? = nil,
+                         onResponse: HTTPRequestOptions.OnResponse? = nil,
                          onBody: HTTPRequestOptions.OnIncomingBody? = nil,
-                         onBlockDone: HTTPRequestOptions.OnIncomingHeadersBlockDone? = nil,
                          onComplete: HTTPRequestOptions.OnStreamComplete? = nil) async throws -> HTTPResponse {
 
         var httpResponse = HTTPResponse()
@@ -45,9 +44,8 @@ class HTTPClientTestFixture: XCBaseTestCase {
                     body: body,
                     response: &httpResponse,
                     semaphore: semaphore,
-                    onIncomingHeaders: onIncomingHeaders,
+                    onResponse: onResponse,
                     onBody: onBody,
-                    onBlockDone: onBlockDone,
                     onComplete: onComplete)
         } else {
             httpRequestOptions = try getHTTPRequestOptions(
@@ -57,9 +55,8 @@ class HTTPClientTestFixture: XCBaseTestCase {
                     body: body,
                     response: &httpResponse,
                     semaphore: semaphore,
-                    onIncomingHeaders: onIncomingHeaders,
+                    onResponse: onResponse,
                     onBody: onBody,
-                    onBlockDone: onBlockDone,
                     onComplete: onComplete)
         }
 
@@ -88,9 +85,8 @@ class HTTPClientTestFixture: XCBaseTestCase {
                           streamManager: HTTP2StreamManager,
                           numRetries: UInt = 2,
                           http2ManualDataWrites: Bool = false,
-                          onIncomingHeaders: HTTPRequestOptions.OnIncomingHeaders? = nil,
+                          onResponse: HTTPRequestOptions.OnResponse? = nil,
                           onBody: HTTPRequestOptions.OnIncomingBody? = nil,
-                          onBlockDone: HTTPRequestOptions.OnIncomingHeadersBlockDone? = nil,
                           onComplete: HTTPRequestOptions.OnStreamComplete? = nil) async throws -> HTTPResponse {
 
         var httpResponse = HTTPResponse()
@@ -104,9 +100,8 @@ class HTTPClientTestFixture: XCBaseTestCase {
                 body: body,
                 response: &httpResponse,
                 semaphore: semaphore,
-                onIncomingHeaders: onIncomingHeaders,
+                onResponse: onResponse,
                 onBody: onBody,
-                onBlockDone: onBlockDone,
                 onComplete: onComplete,
                 http2ManualDataWrites: http2ManualDataWrites)
 
@@ -154,21 +149,16 @@ class HTTPClientTestFixture: XCBaseTestCase {
     func getRequestOptions(request: HTTPRequestBase,
                            response: UnsafeMutablePointer<HTTPResponse>? = nil,
                            semaphore: DispatchSemaphore? = nil,
-                           onIncomingHeaders: HTTPRequestOptions.OnIncomingHeaders? = nil,
+                           onResponse: HTTPRequestOptions.OnResponse? = nil,
                            onBody: HTTPRequestOptions.OnIncomingBody? = nil,
-                           onBlockDone: HTTPRequestOptions.OnIncomingHeadersBlockDone? = nil,
                            onComplete: HTTPRequestOptions.OnStreamComplete? = nil,
                            http2ManualDataWrites: Bool = false) -> HTTPRequestOptions {
         HTTPRequestOptions(request: request,
-                onIncomingHeaders: { statusCode, headerBlock, headers in
-                    for header in headers {
-                        response?.pointee.headers.append(header)
-                    }
-                    onIncomingHeaders?(statusCode, headerBlock, headers)
+                onResponse: { status, headers in
+                    response?.pointee.headers += headers
+                    onResponse?(status, headers)
                 },
-                onIncomingHeadersBlockDone: { block in
-                    onBlockDone?(block)
-                },
+
                 onIncomingBody: { bodyChunk in
                     response?.pointee.body += bodyChunk
                     onBody?(bodyChunk)
@@ -197,9 +187,8 @@ class HTTPClientTestFixture: XCBaseTestCase {
                                response: UnsafeMutablePointer<HTTPResponse>? = nil,
                                semaphore: DispatchSemaphore? = nil,
                                headers: [HTTPHeader] = [HTTPHeader](),
-                               onIncomingHeaders: HTTPRequestOptions.OnIncomingHeaders? = nil,
+                               onResponse: HTTPRequestOptions.OnResponse? = nil,
                                onBody: HTTPRequestOptions.OnIncomingBody? = nil,
-                               onBlockDone: HTTPRequestOptions.OnIncomingHeadersBlockDone? = nil,
                                onComplete: HTTPRequestOptions.OnStreamComplete? = nil
     ) throws -> HTTPRequestOptions {
         let httpRequest: HTTPRequest = try HTTPRequest(method: method, path: path, body: ByteBuffer(data: body.data(using: .utf8)!), allocator: allocator)
@@ -210,9 +199,8 @@ class HTTPClientTestFixture: XCBaseTestCase {
                 request: httpRequest,
                 response: response,
                 semaphore: semaphore,
-                onIncomingHeaders: onIncomingHeaders,
+                onResponse: onResponse,
                 onBody: onBody,
-                onBlockDone: onBlockDone,
                 onComplete: onComplete)
     }
 
@@ -224,9 +212,8 @@ class HTTPClientTestFixture: XCBaseTestCase {
                                 manualDataWrites: Bool = false,
                                 response: UnsafeMutablePointer<HTTPResponse>? = nil,
                                 semaphore: DispatchSemaphore? = nil,
-                                onIncomingHeaders: HTTPRequestOptions.OnIncomingHeaders? = nil,
+                                onResponse: HTTPRequestOptions.OnResponse? = nil,
                                 onBody: HTTPRequestOptions.OnIncomingBody? = nil,
-                                onBlockDone: HTTPRequestOptions.OnIncomingHeadersBlockDone? = nil,
                                 onComplete: HTTPRequestOptions.OnStreamComplete? = nil,
                                 http2ManualDataWrites: Bool = false) throws -> HTTPRequestOptions {
 
@@ -241,9 +228,8 @@ class HTTPClientTestFixture: XCBaseTestCase {
                 request: http2Request,
                 response: response,
                 semaphore: semaphore,
-                onIncomingHeaders: onIncomingHeaders,
+                onResponse: onResponse,
                 onBody: onBody,
-                onBlockDone: onBlockDone,
                 onComplete: onComplete,
                 http2ManualDataWrites: http2ManualDataWrites)
     }

--- a/Test/AwsCommonRuntimeKitTests/http/HTTPClientTestFixture.swift
+++ b/Test/AwsCommonRuntimeKitTests/http/HTTPClientTestFixture.swift
@@ -168,10 +168,8 @@ class HTTPClientTestFixture: XCBaseTestCase {
                     case .success(let status):
                         response?.pointee.statusCode = Int(status)
                     case .failure(let error):
+                        print("AWS_TEST_ERROR:\(String(describing: error))")
                         response?.pointee.error = error
-                    }
-                    if response?.pointee.error != nil {
-                        print("AWS_TEST_ERROR:\(String(describing: response?.pointee.error))")
                     }
                     onComplete?(result)
                     semaphore?.signal()


### PR DESCRIPTION
*Description of changes:*
- Removes Stream pointer from HTTP callbacks which complicates overall logic due to cyclic dependency without providing much value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
