### PR TITLE
Fix generate random callback

### DIFF
--- a/Source/AwsCommonRuntimeKit/crt/ShutdownCallbackCore.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ShutdownCallbackCore.swift
@@ -10,13 +10,16 @@ public typealias ShutdownCallback = () -> Void
 /// You have to balance the retain & release calls in all cases to avoid leaking memory.
 class ShutdownCallbackCore {
     let shutdownCallback: ShutdownCallback
-    init(_ shutdownCallback: ShutdownCallback?) {
+    let data: AnyObject?
+    init(_ shutdownCallback: ShutdownCallback?,
+         data: AnyObject? = nil) {
         if let shutdownCallback = shutdownCallback {
             self.shutdownCallback = shutdownCallback
         } else {
             /// Pass an empty shutdown callback to make manual reference counting easier and avoid null checks.
             self.shutdownCallback = { }
         }
+        self.data = data
     }
 
     /// Calling this function performs a manual retain on the ShutdownCallbackCore.

--- a/Source/AwsCommonRuntimeKit/crt/ShutdownCallbackCore.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ShutdownCallbackCore.swift
@@ -11,6 +11,10 @@ public typealias ShutdownCallback = () -> Void
 class ShutdownCallbackCore {
     let shutdownCallback: ShutdownCallback
     let data: AnyObject?
+
+    /// - Parameters:
+    ///   - shutdownCallback: Shutdown callback to trigger. If it is Nil, it will be replaced with empty callback
+    ///   - data: Pass in any data you want to retain till shutdown callback has fired.
     init(_ shutdownCallback: ShutdownCallback?,
          data: AnyObject? = nil) {
         if let shutdownCallback = shutdownCallback {

--- a/Source/AwsCommonRuntimeKit/crt/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/crt/Utilities.swift
@@ -5,6 +5,17 @@ import struct Foundation.Data
 import struct Foundation.TimeInterval
 import AwsCCal
 
+class Box<T> {
+    let contents: T
+    init(_ contents: T) {
+        self.contents = contents
+    }
+
+    func passUnretained() -> UnsafeMutableRawPointer {
+        return Unmanaged<Box>.passUnretained(self).toOpaque()
+    }
+}
+
 extension String {
 
     public func base64EncodedMD5(allocator: Allocator = defaultAllocator, truncate: Int = 0) throws -> String {

--- a/Source/AwsCommonRuntimeKit/crt/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/crt/Utilities.swift
@@ -5,6 +5,9 @@ import struct Foundation.Data
 import struct Foundation.TimeInterval
 import AwsCCal
 
+/// This class is used to add reference counting to stuff that do not support it
+/// like Structs, Closures, and Protocols etc by wrapping it in a Class.
+/// This also allows us to use anything with Unmanaged which we required for C callbacks.
 class Box<T> {
     let contents: T
     init(_ contents: T) {

--- a/Source/AwsCommonRuntimeKit/event-stream/EventStreamHeader.swift
+++ b/Source/AwsCommonRuntimeKit/event-stream/EventStreamHeader.swift
@@ -15,6 +15,11 @@ public struct EventStreamHeader {
 
     /// value.count can not be greater than EventStreamHeader.maxValueLength for supported types.
     public var value: EventStreamHeaderValue
+
+    public init(name: String, value: EventStreamHeaderValue) {
+        self.name = name
+        self.value = value
+    }
 }
 
 public enum EventStreamHeaderValue: Equatable {

--- a/Source/AwsCommonRuntimeKit/event-stream/EventStreamMessage.swift
+++ b/Source/AwsCommonRuntimeKit/event-stream/EventStreamMessage.swift
@@ -9,6 +9,14 @@ public struct EventStreamMessage {
     var payload: Data = Data()
     var allocator: Allocator = defaultAllocator
 
+    public init(headers: [EventStreamHeader] = [EventStreamHeader](),
+                payload: Data = Data(),
+                allocator: Allocator = defaultAllocator) {
+        self.headers = headers
+        self.payload = payload
+        self.allocator = allocator
+    }
+
     /// Get the binary format of this message (i.e. for sending across the wire manually)
     /// - Returns:  binary Data.
     public func getEncoded() throws -> Data {

--- a/Source/AwsCommonRuntimeKit/http/HTTPMessage.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPMessage.swift
@@ -11,7 +11,7 @@ public class HTTPMessage {
         willSet(value) {
             if let newBody = value {
                 let iStreamCore = IStreamCore(iStreamable: newBody, allocator: allocator)
-                aws_http_message_set_body_stream(self.rawValue, &iStreamCore.rawValue)
+                aws_http_message_set_body_stream(self.rawValue, iStreamCore.rawValue)
             } else {
                 aws_http_message_set_body_stream(self.rawValue, nil)
             }

--- a/Source/AwsCommonRuntimeKit/http/HTTPRequest.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPRequest.swift
@@ -52,7 +52,7 @@ public class HTTPRequest: HTTPMessage {
 
         if let body = body {
             let iStreamCore = IStreamCore(iStreamable: body, allocator: allocator)
-            aws_http_message_set_body_stream(self.rawValue, &iStreamCore.rawValue)
+            aws_http_message_set_body_stream(self.rawValue, iStreamCore.rawValue)
         }
         addHeaders(headers: headers)
     }

--- a/Source/AwsCommonRuntimeKit/io/StreamCore.swift
+++ b/Source/AwsCommonRuntimeKit/io/StreamCore.swift
@@ -6,7 +6,7 @@ import AwsCCommon
 
 /// aws_input_stream has acquire and release functions which manage the lifetime of this object.
 class IStreamCore {
-    var rawValue: aws_input_stream
+    var rawValue: UnsafeMutablePointer<aws_input_stream>
     let iStreamable: IStreamable
     var isEndOfStream: Bool = false
     private let allocator: Allocator
@@ -23,16 +23,17 @@ class IStreamCore {
     init(iStreamable: IStreamable, allocator: Allocator) {
         self.allocator = allocator
         self.iStreamable = iStreamable
-        rawValue = aws_input_stream()
+        rawValue = allocator.allocate(capacity: 1)
         // Use a manually managed vtable pointer to avoid undefined behavior
         self.vtablePointer = allocator.allocate(capacity: 1)
         vtablePointer.initialize(to: vtable)
-        rawValue.vtable = UnsafePointer(vtablePointer)
+        rawValue.pointee.vtable = UnsafePointer(vtablePointer)
 
-        rawValue.impl = Unmanaged<IStreamCore>.passUnretained(self).toOpaque()
+        rawValue.pointee.impl = Unmanaged<IStreamCore>.passUnretained(self).toOpaque()
     }
 
     deinit {
+        allocator.release(rawValue)
         allocator.release(vtablePointer)
     }
 }

--- a/Source/AwsCommonRuntimeKit/io/retryer/RetryStrategy.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/RetryStrategy.swift
@@ -4,6 +4,7 @@
 import AwsCIo
 import Foundation
 
+/// function to supply your own generate random implementation.
 public typealias GenerateRandomFn = () -> UInt64
 
 public class RetryStrategy {

--- a/Source/AwsCommonRuntimeKit/io/retryer/RetryStrategy.swift
+++ b/Source/AwsCommonRuntimeKit/io/retryer/RetryStrategy.swift
@@ -16,6 +16,7 @@ public class RetryStrategy {
     ///   - backOffScaleFactor: (Optional) Scaling factor to add for the backoff. Default is 25ms and maximum is UInt32 ms.
     ///   - jitterMode: (Optional) Jitter mode to use, see comments for aws_exponential_backoff_jitter_mode.
     ///   - generateRandom: (Optional) By default this will be set to use aws_device_random. If you want something else, set it here.
+    ///   - shutdownCallback: (Optional) Shutdown callback to invoke when the resource is cleaned up.
     ///   - allocator: (Optional) allocator to override.
     /// - Returns: `CRTAWSRetryStrategy`
     public init(eventLoopGroup: EventLoopGroup,
@@ -23,7 +24,8 @@ public class RetryStrategy {
                 maxRetries: Int = 10,
                 backOffScaleFactor: TimeInterval = 0.025,
                 jitterMode: ExponentialBackoffJitterMode = .default,
-                generateRandom: (@convention(c) () -> UInt64)? = nil,
+                generateRandom: (() -> UInt64)? = nil,
+                shutdownCallback: ShutdownCallback? = nil,
                 allocator: Allocator = defaultAllocator) throws {
 
         var exponentialBackoffRetryOptions = aws_exponential_backoff_retry_options()

--- a/Test/AwsCommonRuntimeKitTests/auth/CredentialsProviderTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/auth/CredentialsProviderTests.swift
@@ -52,14 +52,19 @@ class CredentialsProviderTests: XCBaseTestCase {
     func testDelegateCredentialsProvider() async throws {
         shutdownWasCalled.expectedFulfillmentCount = 2
         do {
-            let staticProvider = try CredentialsProvider(source: .static(accessKey: accessKey,
-                    secret: secret,
-                    sessionToken: sessionToken,
-                    shutdownCallback: getShutdownCallback()),
-                    allocator: allocator)
-            let delegateProvider = try CredentialsProvider(provider: staticProvider,
-                    shutdownCallback: getShutdownCallback(),
-                    allocator: allocator)
+
+            let delegateProvider: CredentialsProvider!
+            // make sure actual Credentials Provider goes out of scope
+            do {
+                let staticProvider = try CredentialsProvider(source: .static(accessKey: accessKey,
+                        secret: secret,
+                        sessionToken: sessionToken,
+                        shutdownCallback: getShutdownCallback()),
+                        allocator: allocator)
+                delegateProvider = try CredentialsProvider(provider: staticProvider,
+                        shutdownCallback: getShutdownCallback(),
+                        allocator: allocator)
+            }
             let credentials = try await delegateProvider.getCredentials()
             XCTAssertNotNil(credentials)
             assertCredentials(credentials: credentials)


### PR DESCRIPTION
Issue #127 

*Description of changes:*
- Expose generateRandom as a non-C closure after relevant changes in C
- A new pattern for to retain callbacks until shutdown callback has fired which doesn't require double retain/release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
