### PR TITLE
Override Default Allocator

### DIFF
--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -2,7 +2,7 @@ import AwsCEventStream
 import AwsCAuth
 
 /**
- * Used to initialize the library.
+ * Initializes the library.
  * `CommonRuntimeKit.initialize` must be called before using any other functionality.
  */
 public struct CommonRuntimeKit {

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -8,7 +8,7 @@ import AwsCAuth
 public struct CommonRuntimeKit {
 
     /**
-     * Initializes internal stuff used by CommonRuntimeKit.
+     * Initializes the library.
      * Must be called before using any other functionality.
      */
     public static func initialize(allocator: Allocator = defaultAllocator) {

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -11,7 +11,7 @@ public struct CommonRuntimeKit {
     /// Must be called before using any other functionality.
     /// - Parameters:
     ///   - allocator: (Optional) default allocator to override
-    ///   - overrideDefaultAllocator: (Optional) Set it to true to override default allocator for the duration of whole application.
+    ///   - overrideDefaultAllocator: (Optional) Set it to true to override default allocator for the duration of application.
     ///                               This feature is mainly intended for tests and is not typically needed.
     public static func initialize(allocator: Allocator = defaultAllocator, overrideDefaultAllocator: Bool = false) {
         aws_auth_library_init(allocator.rawValue)

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -7,8 +7,8 @@ import AwsCAuth
  */
 public struct CommonRuntimeKit {
 
-     /// Initializes the library.
-     /// Must be called before using any other functionality.
+    /// Initializes the library.
+    /// Must be called before using any other functionality.
     /// - Parameters:
     ///   - allocator: (Optional) default allocator to override
     ///   - overrideDefaultAllocator: (Optional) Set it to true to override default allocator for the duration of whole application.
@@ -16,7 +16,7 @@ public struct CommonRuntimeKit {
     public static func initialize(allocator: Allocator = defaultAllocator, overrideDefaultAllocator: Bool = false) {
         aws_auth_library_init(allocator.rawValue)
         aws_event_stream_library_init(allocator.rawValue)
-        if(overrideDefaultAllocator) {
+        if overrideDefaultAllocator {
             defaultAllocator = allocator.rawValue
         }
     }

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -7,23 +7,18 @@ import AwsCAuth
  */
 public struct CommonRuntimeKit {
 
-    /**
-     * Initializes the library.
-     * Must be called before using any other functionality.
-     */
-    public static func initialize(allocator: Allocator = defaultAllocator) {
+     /// Initializes the library.
+     /// Must be called before using any other functionality.
+    /// - Parameters:
+    ///   - allocator: (Optional) default allocator to override
+    ///   - overrideDefaultAllocator: (Optional) Set it to true to override default allocator for the duration of whole application.
+    ///                               This feature is mainly intended for tests and is not typically needed.
+    public static func initialize(allocator: Allocator = defaultAllocator, overrideDefaultAllocator: Bool = false) {
         aws_auth_library_init(allocator.rawValue)
         aws_event_stream_library_init(allocator.rawValue)
-    }
-
-    /**
-     * This is an alternative constructor mainly for testing.
-     * Use this instead if you want to override defaultAllocator.
-     */
-    public static func initialize(customDefaultAllocator: Allocator) {
-        aws_auth_library_init(customDefaultAllocator.rawValue)
-        aws_event_stream_library_init(customDefaultAllocator.rawValue)
-        defaultAllocator = customDefaultAllocator.rawValue
+        if(overrideDefaultAllocator) {
+            defaultAllocator = allocator.rawValue
+        }
     }
 
     /**

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -29,7 +29,7 @@ public struct CommonRuntimeKit {
     /**
      * This is an optional cleanup function which will block until all the CRT resources have cleaned up.
      * Use this function only if you want to make sure that there are no memory leaks at the end of the application.
-     * Warning: It will hang forever if you are still holding references to CRT Objects such as HostResolver.
+     * Warning: It will hang if you are still holding references to any CRT objects such as HostResolver.
      */
     public static func cleanUp() {
         aws_auth_library_clean_up()

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -29,7 +29,7 @@ public struct CommonRuntimeKit {
     /**
      * This is an optional cleanup function which will block until all the CRT resources have cleaned up.
      * Use this function only if you want to make sure that there are no memory leaks at the end of the application.
-     * Warning: It will hang forever if you are still holding references to CRT Objects like HostResolver.
+     * Warning: It will hang forever if you are still holding references to CRT Objects such as HostResolver.
      */
     public static func cleanUp() {
         aws_auth_library_clean_up()

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -1,13 +1,36 @@
 import AwsCEventStream
 import AwsCAuth
 
+/**
+ * Used to initialize the library.
+ * `CommonRuntimeKit.initialize` must be called before using any other functionality.
+ */
 public struct CommonRuntimeKit {
 
+    /**
+     * Initializes internal stuff used by CommonRuntimeKit.
+     * Must be called before using any other functionality.
+     */
     public static func initialize(allocator: Allocator = defaultAllocator) {
         aws_auth_library_init(allocator.rawValue)
         aws_event_stream_library_init(allocator.rawValue)
     }
 
+    /**
+     * This is an alternative constructor mainly for testing.
+     * Use this instead if you want to override defaultAllocator.
+     */
+    public static func initialize(customDefaultAllocator: Allocator) {
+        aws_auth_library_init(customDefaultAllocator.rawValue)
+        aws_event_stream_library_init(customDefaultAllocator.rawValue)
+        defaultAllocator = customDefaultAllocator.rawValue
+    }
+
+    /**
+     * This is an optional cleanup function which will block until all the CRT resources have cleaned up.
+     * Use this function only if you want to make sure that there are no memory leaks at the end of the application.
+     * Warning: It will hang forever if you are still holding references to CRT Objects like HostResolver.
+     */
     public static func cleanUp() {
         aws_auth_library_clean_up()
         aws_event_stream_library_clean_up()

--- a/Source/AwsCommonRuntimeKit/crt/Allocator.swift
+++ b/Source/AwsCommonRuntimeKit/crt/Allocator.swift
@@ -6,7 +6,7 @@ import AwsCCommon
  The default allocator.
  You are probably looking to use `allocator` instead.
  */
-public let defaultAllocator = aws_default_allocator()!
+internal(set) public var defaultAllocator = aws_default_allocator()!
 
 /// An allocator is used to allocate memory on the heap.
 public protocol Allocator {

--- a/Test/AwsCommonRuntimeKitTests/XCBaseTestCase.swift
+++ b/Test/AwsCommonRuntimeKitTests/XCBaseTestCase.swift
@@ -12,7 +12,7 @@ class XCBaseTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        CommonRuntimeKit.initialize(allocator: self.allocator)
+        CommonRuntimeKit.initialize(customDefaultAllocator: allocator)
     }
 
     override func tearDown() {

--- a/Test/AwsCommonRuntimeKitTests/XCBaseTestCase.swift
+++ b/Test/AwsCommonRuntimeKitTests/XCBaseTestCase.swift
@@ -11,8 +11,7 @@ class XCBaseTestCase: XCTestCase {
 
     override func setUp() {
         super.setUp()
-
-        CommonRuntimeKit.initialize(customDefaultAllocator: allocator)
+        CommonRuntimeKit.initialize(allocator: allocator, overrideDefaultAllocator: true)
     }
 
     override func tearDown() {

--- a/Test/AwsCommonRuntimeKitTests/auth/ChunkSignerTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/auth/ChunkSignerTests.swift
@@ -36,8 +36,7 @@ class ChunkSignerTests: XCBaseTestCase {
         let request = makeChunkedRequest()
         let signedRequest = try await Signer.signRequest(
                 request: request,
-                config: makeChunkedRequestSigningConfig(),
-                allocator: allocator)
+                config: makeChunkedRequestSigningConfig())
         XCTAssertNotNil(signedRequest)
         let headers = signedRequest.getHeaders()
 
@@ -48,29 +47,25 @@ class ChunkSignerTests: XCBaseTestCase {
         let firstChunkSignature = try await Signer.signChunk(
                 chunk: Data(repeating: 97, count: chunk1Size),
                 previousSignature: expectedRequestSignature,
-                config: makeChunkedSigningConfig(),
-                allocator: allocator)
+                config: makeChunkedSigningConfig())
         XCTAssertEqual(firstChunkSignature, expectedFirstChunkSignature)
 
         let secondChunkSignature = try await Signer.signChunk(
                 chunk: Data(repeating: 97, count: chunk2Size),
                 previousSignature: expectedFirstChunkSignature,
-                config: makeChunkedSigningConfig(),
-                allocator: allocator)
+                config: makeChunkedSigningConfig())
         XCTAssertEqual(secondChunkSignature, expectedSecondChunkSignature)
 
         let finalChunkSignature = try await Signer.signChunk(
                 chunk: Data(),
                 previousSignature: secondChunkSignature,
-                config: makeChunkedSigningConfig(),
-                allocator: allocator)
+                config: makeChunkedSigningConfig())
         XCTAssertEqual(finalChunkSignature, expectedFinalChunkSignature)
 
         let trailerChunkSignature = try await Signer.signTrailerHeaders(
                 headers: trailingHeaders,
                 previousSignature: finalChunkSignature,
-                config: makeTrailingSigningConfig(),
-                allocator: allocator)
+                config: makeTrailingSigningConfig())
         XCTAssertEqual(trailerChunkSignature, expectedTrailerHeaderSignature)
     }
 

--- a/Test/AwsCommonRuntimeKitTests/auth/ChunkSignerTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/auth/ChunkSignerTests.swift
@@ -36,7 +36,8 @@ class ChunkSignerTests: XCBaseTestCase {
         let request = makeChunkedRequest()
         let signedRequest = try await Signer.signRequest(
                 request: request,
-                config: makeChunkedRequestSigningConfig())
+                config: makeChunkedRequestSigningConfig(),
+                allocator: allocator)
         XCTAssertNotNil(signedRequest)
         let headers = signedRequest.getHeaders()
 
@@ -47,25 +48,29 @@ class ChunkSignerTests: XCBaseTestCase {
         let firstChunkSignature = try await Signer.signChunk(
                 chunk: Data(repeating: 97, count: chunk1Size),
                 previousSignature: expectedRequestSignature,
-                config: makeChunkedSigningConfig())
+                config: makeChunkedSigningConfig(),
+                allocator: allocator)
         XCTAssertEqual(firstChunkSignature, expectedFirstChunkSignature)
 
         let secondChunkSignature = try await Signer.signChunk(
                 chunk: Data(repeating: 97, count: chunk2Size),
                 previousSignature: expectedFirstChunkSignature,
-                config: makeChunkedSigningConfig())
+                config: makeChunkedSigningConfig(),
+                allocator: allocator)
         XCTAssertEqual(secondChunkSignature, expectedSecondChunkSignature)
 
         let finalChunkSignature = try await Signer.signChunk(
                 chunk: Data(),
                 previousSignature: secondChunkSignature,
-                config: makeChunkedSigningConfig())
+                config: makeChunkedSigningConfig(),
+                allocator: allocator)
         XCTAssertEqual(finalChunkSignature, expectedFinalChunkSignature)
 
         let trailerChunkSignature = try await Signer.signTrailerHeaders(
                 headers: trailingHeaders,
                 previousSignature: finalChunkSignature,
-                config: makeTrailingSigningConfig())
+                config: makeTrailingSigningConfig(),
+                allocator: allocator)
         XCTAssertEqual(trailerChunkSignature, expectedTrailerHeaderSignature)
     }
 


### PR DESCRIPTION
*Description of changes:*
- Always override defaultAllocator with tracingAllocator in tests. I would have preferred to make it internal, but it needs to be public to override in tests `onSetup`.
- Add documentation for `CommonRuntimeKit` and warn users about the dangers of cleanup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
