### PR TITLE
Remove arch based conditionals

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,10 +63,10 @@ var awsCCalPlatformExcludes = [
     "ecdsa-fuzz-corpus/windows/p256_sig_corpus.txt",
     "ecdsa-fuzz-corpus/darwin/p256_sig_corpus.txt"] + excludesFromAll
 
-#if os(macOS) || os(iOS)
+#if os(macOS)
 awsCCalPlatformExcludes.append("source/windows")
 awsCCalPlatformExcludes.append("source/unix")
-#elseif(Windows)
+#elseif os(Windows)
 awsCCalPlatformExcludes.append("source/darwin")
 awsCCalPlatformExcludes.append("source/unix")
 #else

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,6 @@ var awsCCommonPlatformExcludes = ["source/android",
                                   "scripts/appverifier_ctest.py",
                                   "scripts/appverifier_xml.py"] + excludesFromAll
 
-
 // includes arch/generic
 awsCCommonPlatformExcludes.append("source/arch/intel")
 awsCCommonPlatformExcludes.append("source/arch/arm")

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let cSettings: [CSetting] = [
 //////////////////////////////////////////////////////////////////////
 /// Configure C targets.
 /// Note: We can not use unsafe flags because SwiftPM makes the target ineligible for use by other packages.
+///       We are also not using any architecture based conditionals due to lack of proper cross compilation support.
 /// Configure aws-c-common
 //////////////////////////////////////////////////////////////////////
 var awsCCommonPlatformExcludes = ["source/android",
@@ -29,20 +30,11 @@ var awsCCommonPlatformExcludes = ["source/android",
                                   "include/aws/common/", "sanitizer-blacklist.txt",
                                   "scripts/appverifier_ctest.py",
                                   "scripts/appverifier_xml.py"] + excludesFromAll
-// Swift never uses MSVC
-awsCCommonPlatformExcludes.append("source/arch/intel/msvc")
-awsCCommonPlatformExcludes.append("source/arch/arm/msvc")
 
-#if arch(arm64) && !os(Windows)
-// includes arch/arm
-awsCCommonPlatformExcludes.append("source/arch/intel")
-awsCCommonPlatformExcludes.append("source/arch/generic")
-#else
+
 // includes arch/generic
 awsCCommonPlatformExcludes.append("source/arch/intel")
 awsCCommonPlatformExcludes.append("source/arch/arm")
-#endif
-
 #if !os(Windows)
 awsCCommonPlatformExcludes.append("source/windows")
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -24,31 +24,27 @@ let cSettings: [CSetting] = [
 /// Note: We can not use unsafe flags because SwiftPM makes the target ineligible for use by other packages.
 /// Configure aws-c-common
 //////////////////////////////////////////////////////////////////////
-var awsCCommonPlatformExcludes = ["source/windows", "source/android",
+var awsCCommonPlatformExcludes = ["source/android",
                                   "AWSCRTAndroidTestRunner", "verification",
                                   "include/aws/common/", "sanitizer-blacklist.txt",
                                   "scripts/appverifier_ctest.py",
                                   "scripts/appverifier_xml.py"] + excludesFromAll
+// Swift never uses MSVC
+awsCCommonPlatformExcludes.append("source/arch/intel/msvc")
+awsCCommonPlatformExcludes.append("source/arch/arm/msvc")
 
-#if arch(i386) || arch(x86_64)
-awsCCommonPlatformExcludes.append("source/arch/arm")
-// temporary cause I can't use intrensics because swiftpm doesn't like the necessary compiler flag.
-awsCCommonPlatformExcludes.append("source/arch/intel")
-// unsafeFlagsArray.append("-mavx512f")
-#elseif arch(arm64)
+#if arch(arm64) && !os(Windows)
+// includes arch/arm
 awsCCommonPlatformExcludes.append("source/arch/intel")
 awsCCommonPlatformExcludes.append("source/arch/generic")
 #else
+// includes arch/generic
 awsCCommonPlatformExcludes.append("source/arch/intel")
 awsCCommonPlatformExcludes.append("source/arch/arm")
 #endif
 
 #if !os(Windows)
-awsCCommonPlatformExcludes.append("source/arch/intel/msvc")
-awsCCommonPlatformExcludes.append("source/arch/arm/msvc")
-#else
-awsCCommonPlatformExcludes.append("source/arch/intel/asm")
-awsCCommonPlatformExcludes.append("source/arch/arm/asm")
+awsCCommonPlatformExcludes.append("source/windows")
 #endif
 
 //////////////////////////////////////////////////////////////////////
@@ -75,7 +71,7 @@ var awsCCalPlatformExcludes = [
     "ecdsa-fuzz-corpus/windows/p256_sig_corpus.txt",
     "ecdsa-fuzz-corpus/darwin/p256_sig_corpus.txt"] + excludesFromAll
 
-#if os(macOS)
+#if os(macOS) || os(iOS)
 awsCCalPlatformExcludes.append("source/windows")
 awsCCalPlatformExcludes.append("source/unix")
 #elseif(Windows)
@@ -155,6 +151,7 @@ var awsCChecksumsExcludes = [
 
 // swift never uses Microsoft Visual C++ compiler
 awsCChecksumsExcludes.append("source/intel/visualc")
+
 // TODO: enable hardware acceleration https://github.com/awslabs/aws-sdk-swift/issues/867
 // #if arch(arm64)
 //// includes source/arm

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let cSettings: [CSetting] = [
 //////////////////////////////////////////////////////////////////////
 var awsCCommonPlatformExcludes = ["source/android",
                                   "AWSCRTAndroidTestRunner", "verification",
-                                  "include/aws/common/", "sanitizer-blacklist.txt",
+                                  "include/aws/common/",
                                   "scripts/appverifier_ctest.py",
                                   "scripts/appverifier_xml.py"] + excludesFromAll
 
@@ -62,15 +62,15 @@ var awsCCalPlatformExcludes = [
     "ecdsa-fuzz-corpus/windows/p256_sig_corpus.txt",
     "ecdsa-fuzz-corpus/darwin/p256_sig_corpus.txt"] + excludesFromAll
 
-#if os(macOS)
-awsCCalPlatformExcludes.append("source/windows")
-awsCCalPlatformExcludes.append("source/unix")
-#elseif os(Windows)
+#if os(Windows)
 awsCCalPlatformExcludes.append("source/darwin")
 awsCCalPlatformExcludes.append("source/unix")
-#else
+#elseif os(Linux)
 awsCCalPlatformExcludes.append("source/windows")
 awsCCalPlatformExcludes.append("source/darwin")
+#else  // macOS, iOS, watchOS, tvOS
+awsCCalPlatformExcludes.append("source/windows")
+awsCCalPlatformExcludes.append("source/unix")
 #endif
 
 //////////////////////////////////////////////////////////////////////
@@ -113,19 +113,19 @@ ioDependencies.append("S2N")
 cSettingsIO.append(.define("USE_S2N"))
 #endif
 
-#if os(macOS)
-awsCIoPlatformExcludes.append("source/windows")
-awsCIoPlatformExcludes.append("source/linux")
-awsCIoPlatformExcludes.append("source/s2n")
-#elseif(Windows)
+#if os(Windows)
 awsCIoPlatformExcludes.append("source/posix")
 awsCIoPlatformExcludes.append("source/linux")
 awsCIoPlatformExcludes.append("source/s2n")
 awsCIoPlatformExcludes.append("source/darwin")
-#else
+#elseif os(Linux)
 awsCIoPlatformExcludes.append("source/windows")
 awsCIoPlatformExcludes.append("source/bsd")
 awsCIoPlatformExcludes.append("source/darwin")
+#else  // macOS, iOS, watchOS, tvOS
+awsCIoPlatformExcludes.append("source/windows")
+awsCIoPlatformExcludes.append("source/linux")
+awsCIoPlatformExcludes.append("source/s2n")
 #endif
 
 //////////////////////////////////////////////////////////////////////
@@ -177,7 +177,6 @@ var awsCHttpPlatformExcludes = [
     "integration-testing",
     "include/aws/http/private",
     "CODE_OF_CONDUCT.md",
-    "sanitizer-blacklist.txt",
     "codebuild/linux-integration-tests.yml"] + excludesFromAll
 
 //////////////////////////////////////////////////////////////////////

--- a/Package.swift
+++ b/Package.swift
@@ -143,7 +143,6 @@ var awsCChecksumsExcludes = [
 
 // swift never uses Microsoft Visual C++ compiler
 awsCChecksumsExcludes.append("source/intel/visualc")
-
 // TODO: enable hardware acceleration https://github.com/awslabs/aws-sdk-swift/issues/867
 // #if arch(arm64)
 //// includes source/arm


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-crt-swift/issues/159
*Description of changes:*

The Package.swift file is compiled at compile-time, and SwiftPM is not yet mature enough to handle complex cross-compilations. Remove the #if directive for the architecture. This particular #if directive wouldn't have created an issue because:
- We always excluded the intel folder.
- For ARM, in the C code, we only have a runtime check for Linux and BSD.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
