### PR TITLE
Change CI to Push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 
 on:
-  pull_request:
+  push:
+    branches-ignore:
+      - 'main'
 
 env:
   BUILDER_VERSION: v0.9.28


### PR DESCRIPTION
This makes malicious pull requests harder to pull off. CI won't run unless code is pushed to THIS repo, which only team members can do.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
