### PR TITLE
Fix ECSCredentialsProvider to Make AuthToken Optional

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -279,7 +279,7 @@ packageTargets.append(contentsOf: [
         dependencies: ["AwsCommonRuntimeKit"],
         path: "Test/AwsCommonRuntimeKitTests",
         resources: [
-            .copy("Resources")
+            .process("Resources")
         ]
     ),
     .executableTarget(

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CredentialsProvider.swift
@@ -466,7 +466,7 @@ extension CredentialsProvider.Source {
     /// - Throws: CommonRuntimeError.crtError
     public static func `ecs`(bootstrap: ClientBootstrap,
                              tlsContext: TLSContext? = nil,
-                             authToken: String,
+                             authToken: String? = nil,
                              pathAndQuery: String,
                              host: String,
                              shutdownCallback: ShutdownCallback? = nil) -> Self {


### PR DESCRIPTION
*Issue #, if available:*
#174 

*Description of changes:*
- Make auth token optional
- Host & PathandQuery is required as the C implementation does not read the env variables for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
