### PR TITLE
App Store fix, take 2

### DIFF
--- a/aws-common-runtime/config/aws/common/config.h
+++ b/aws-common-runtime/config/aws/common/config.h
@@ -43,3 +43,6 @@
 #define AWS_HAVE_EXECINFO 1
 /* Disable Intel VTune tracing API here since aws-crt-swift doesn't use CMake */
 #define INTEL_NO_ITTNOTIFY_API
+
+/* Don't use APIs forbidden by App Stores (e.g. non-public system APIs) */
+#define AWS_APPSTORE_SAFE 1


### PR DESCRIPTION
Stop using private OS APIs on ALL builds, not just iOS.

Related: https://github.com/awslabs/aws-c-cal/pull/171

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
