### PR TITLE
Drop Support for Swift 5.5 and 5.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: swift-5.7
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.9.51
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-swift
   RUN: ${{ github.run_id }}-${{ github.run_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.28
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: swift-5.7
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-swift
   RUN: ${{ github.run_id }}-${{ github.run_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
           aws s3 cp --debug s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-swift-5-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }}
   osx:
-    runs-on: macos-11
+    runs-on: macos-12
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app
+      DEVELOPER_DIR: /Applications/Xcode.app
     steps:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
@@ -51,9 +51,9 @@ jobs:
 
   # TODO: Run tests for devices
   devices:
-    runs-on: macos-11
+    runs-on: macos-12
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app
+      DEVELOPER_DIR: /Applications/Xcode.app
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.51
+  BUILDER_VERSION: v0.9.52
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-swift

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,9 @@ var awsCCommonPlatformExcludes = ["source/android",
                                   "AWSCRTAndroidTestRunner", "verification",
                                   "include/aws/common/",
                                   "scripts/appverifier_ctest.py",
-                                  "scripts/appverifier_xml.py"] + excludesFromAll
+                                  "scripts/appverifier_xml.py",
+                                  "source/linux/system_info.c",
+                                  "bin/"] + excludesFromAll
 
 // includes arch/generic
 awsCCommonPlatformExcludes.append("source/arch/intel")

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 import PackageDescription
 
 let excludesFromAll = ["tests", "cmake", "CONTRIBUTING.md",


### PR DESCRIPTION
*Issue #, if available:*
#204 

*Description of changes:*
- Bump minimum Swift version to 5.7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
