### PR TITLE
Fix String Decode Crash

### DIFF
--- a/Source/AwsCommonRuntimeKit/crt/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/crt/Utilities.swift
@@ -136,7 +136,7 @@ extension aws_byte_cursor {
     func toOptionalString() -> String? {
         if self.len == 0 { return nil }
         let data = Data(bytesNoCopy: self.ptr, count: self.len, deallocator: .none)
-        return String(decoding: data, as: UTF8.self)
+        return String(data: data, encoding: .utf8)
     }
 }
 

--- a/Source/AwsCommonRuntimeKit/crt/Utilities.swift
+++ b/Source/AwsCommonRuntimeKit/crt/Utilities.swift
@@ -130,13 +130,13 @@ extension aws_byte_cursor {
         }
 
         let data = Data(bytesNoCopy: self.ptr, count: self.len, deallocator: .none)
-        return String(data: data, encoding: .utf8)!
+        return String(decoding: data, as: UTF8.self)
     }
 
     func toOptionalString() -> String? {
         if self.len == 0 { return nil }
         let data = Data(bytesNoCopy: self.ptr, count: self.len, deallocator: .none)
-        return String(data: data, encoding: .utf8)!
+        return String(decoding: data, as: UTF8.self)
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#212 

*Description of changes:*
- If the raw bytes encoding of headers is not UTF-8, the force unwrapping will crash. Change it to try to decode it as utf-8 replace invalid characters with unknown characters (�).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
