### PR TITLE
Improves documentation in Package.swift regarding lack of CPU flags.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -144,11 +144,11 @@ var awsCChecksumsExcludes = [
 // swift never uses Microsoft Visual C++ compiler
 awsCChecksumsExcludes.append("source/intel/visualc")
 
-// Hardware accellarated checksums are disabled because Swift PM doesn't like the necessary compiler flag.
-// We can add it once Swift package manager has the necessary support for compiler flags or build C libraries
+// Hardware accelerated checksums are disabled because Swift PM doesn't like the necessary compiler flags.
+// We can add it once Swift package manager has the necessary support for CPU flags or builds C libraries
 // using CMake.
 // See: https://github.com/apple/swift-package-manager/issues/4555
-// Also see issue: https://github.com/awslabs/aws-sdk-swift/issues/867 before enabling hardware accelarated checksums.
+// Also, see issue: https://github.com/awslabs/aws-sdk-swift/issues/867 before enabling hardware accelerated checksums.
 // includes source/generic
 awsCChecksumsExcludes.append("source/arm")
 awsCChecksumsExcludes.append("source/intel")

--- a/Package.swift
+++ b/Package.swift
@@ -143,8 +143,10 @@ var awsCChecksumsExcludes = [
 
 // swift never uses Microsoft Visual C++ compiler
 awsCChecksumsExcludes.append("source/intel/visualc")
+
 // Hardware accellarated checksums are disabled because Swift PM doesn't like the necessary compiler flag.
-// We can add it once Swift PM manager has the necessary support for compiler flags or build using CMake.
+// We can add it once Swift package manager has the necessary support for compiler flags or build C libraries
+// using CMake.
 // See: https://github.com/apple/swift-package-manager/issues/4555
 // Also see issue: https://github.com/awslabs/aws-sdk-swift/issues/867 before enabling hardware accelarated checksums.
 // includes source/generic

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ var awsCCommonPlatformExcludes = ["source/android",
                                   "source/linux/system_info.c",
                                   "bin/"] + excludesFromAll
 
-// includes arch/generic because the Swift PM doesn't like the necessary compiler flags.
+// includes arch/generic because the SwiftPM doesn't like the necessary compiler flags.
 awsCCommonPlatformExcludes.append("source/arch/intel")
 awsCCommonPlatformExcludes.append("source/arch/arm")
 #if !os(Windows)
@@ -144,8 +144,8 @@ var awsCChecksumsExcludes = [
 // swift never uses Microsoft Visual C++ compiler
 awsCChecksumsExcludes.append("source/intel/visualc")
 
-// Hardware accelerated checksums are disabled because Swift PM doesn't like the necessary compiler flags.
-// We can add it once Swift package manager has the necessary support for CPU flags or builds C libraries
+// Hardware accelerated checksums are disabled because SwiftPM doesn't like the necessary compiler flags.
+// We can add it once SwiftPM has the necessary support for CPU flags or builds C libraries
 // using CMake.
 // See: https://github.com/apple/swift-package-manager/issues/4555
 // Also, see issue: https://github.com/awslabs/aws-sdk-swift/issues/867 before enabling hardware accelerated checksums.

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ var awsCCommonPlatformExcludes = ["source/android",
                                   "source/linux/system_info.c",
                                   "bin/"] + excludesFromAll
 
-// includes arch/generic
+// includes arch/generic because the Swift PM doesn't like the necessary compiler flags.
 awsCCommonPlatformExcludes.append("source/arch/intel")
 awsCCommonPlatformExcludes.append("source/arch/arm")
 #if !os(Windows)
@@ -143,21 +143,13 @@ var awsCChecksumsExcludes = [
 
 // swift never uses Microsoft Visual C++ compiler
 awsCChecksumsExcludes.append("source/intel/visualc")
-// TODO: enable hardware acceleration https://github.com/awslabs/aws-sdk-swift/issues/867
-// #if arch(arm64)
-//// includes source/arm
-//// TODO: look at the compiler flag in C
-// awsCChecksumsExcludes.append("source/intel")
-// awsCChecksumsExcludes.append("source/generic")
-// #elseif arch(x86_64) || arch(i386)
-//// include src/intel/asm
-// awsCChecksumsExcludes.append("source/arm")
-// awsCChecksumsExcludes.append("source/generic")
-// #else
+// Hardware accellarated checksums are disabled because Swift PM doesn't like the necessary compiler flag.
+// We can add it once Swift PM manager has the necessary support for compiler flags or build using CMake.
+// See: https://github.com/apple/swift-package-manager/issues/4555
+// Also see issue: https://github.com/awslabs/aws-sdk-swift/issues/867 before enabling hardware accelarated checksums.
 // includes source/generic
 awsCChecksumsExcludes.append("source/arm")
 awsCChecksumsExcludes.append("source/intel")
-// #endif
 
 //////////////////////////////////////////////////////////////////////
 /// aws-c-sdkutils


### PR DESCRIPTION
*Issue #, if available:*
#210 

*Description of changes:*
- Improves documentation around why we have disabled the hardware-accelerated checksum in Swift.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
