### PR TITLE
feat: Add `fetch_metrics()` for HTTP connection managers

### DIFF
--- a/Source/AwsCommonRuntimeKit/http/HTTP2StreamManager.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTP2StreamManager.swift
@@ -42,6 +42,21 @@ public class HTTP2StreamManager {
         })
     }
 
+    /// Fetch the current manager metrics from connection manager.
+    public func fetchMetrics() throws -> HTTPClientConnectionManagerMetrics {
+        do {
+            var cManagerMetrics = aws_http_manager_metrics()
+            aws_http2_stream_manager_fetch_metrics(rawValue, &cManagerMetrics)
+            return HTTPClientConnectionManagerMetrics(
+                availableConcurrency: cManagerMetrics.available_concurrency,
+                pendingConcurrencyAcquires: cManagerMetrics.pending_concurrency_acquires,
+                leasedConcurrency: cManagerMetrics.leased_concurrency
+            )
+        } catch {
+            throw CommonRunTimeError.crtError(.makeFromLastError())
+        }
+    }
+
     deinit {
         aws_http2_stream_manager_release(rawValue)
     }

--- a/Source/AwsCommonRuntimeKit/http/HTTPClientConnectionManager.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPClientConnectionManager.swift
@@ -39,6 +39,21 @@ public class HTTPClientConnectionManager {
         }
     }
 
+    /// Fetch the current manager metrics from connection manager.
+    public func fetchMetrics() throws -> HTTPClientConnectionManagerMetrics {
+        do {
+            var cManagerMetrics = aws_http_manager_metrics()
+            aws_http_connection_manager_fetch_metrics(rawValue, &cManagerMetrics)
+            return HTTPClientConnectionManagerMetrics(
+                availableConcurrency: cManagerMetrics.available_concurrency,
+                pendingConcurrencyAcquires: cManagerMetrics.pending_concurrency_acquires,
+                leasedConcurrency: cManagerMetrics.leased_concurrency
+            )
+        } catch {
+            throw CommonRunTimeError.crtError(.makeFromLastError())
+        }
+    }
+
     deinit {
         aws_http_connection_manager_release(rawValue)
     }

--- a/Source/AwsCommonRuntimeKit/http/HTTPClientConnectionManagerMetrics.swift
+++ b/Source/AwsCommonRuntimeKit/http/HTTPClientConnectionManagerMetrics.swift
@@ -1,0 +1,26 @@
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0.
+
+public struct HTTPClientConnectionManagerMetrics {
+    /// The number of additional concurrent requests that can be supported by the HTTP manager without needing to
+    /// establish additional connections to the target server.
+    ///
+    /// For connection manager, it equals to connections that's idle.
+    /// For stream manager, it equals to the number of streams that are possible to be made without creating new
+    /// connection, although the implementation can create new connection without fully filling it.
+    public var availableConcurrency: Int
+    /// The number of requests that are awaiting concurrency to be made available from the HTTP manager.
+    public var pendingConcurrencyAcquires: Int
+    /// The number of connections (http/1.1) or streams (for h2 via. stream manager) currently vended to user.
+    public var leasedConcurrency: Int
+
+    public init(
+        availableConcurrency: Int = 0,
+        pendingConcurrencyAcquires: Int = 0,
+        leasedConcurrency: Int = 0
+    ) {
+        self.availableConcurrency = availableConcurrency
+        self.pendingConcurrencyAcquires = pendingConcurrencyAcquires
+        self.leasedConcurrency = leasedConcurrency
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/aws-sdk-swift/issues/696

*Description of changes:*

*Related to: https://github.com/smithy-lang/smithy-swift/pull/735, https://github.com/awslabs/aws-sdk-swift/pull/1582*

For the AWS SDK for Swift Observability changes, using the `fetch_metrics()` APIs for the HTTP connection managers is needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
