### PR TITLE
[Windows] Build and test on Windows.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -198,6 +198,14 @@ let awsCEventStreamExcludes = [
     "CODE_OF_CONDUCT.md",
     "clang-tidy/run-clang-tidy.sh"] + excludesFromAll
 
+//////////////////////////////////////////////////////////////////////
+/// AwsCommonRuntimeKitTests
+//////////////////////////////////////////////////////////////////////
+var awsCommonRuntimeKitTestsExcludes: [String] = []
+#if !os(Windows)
+awsCommonRuntimeKitTestsExcludes.append("shims/windows")
+#endif
+
 packageTargets.append(contentsOf: [
     .target(
         name: "AwsCPlatformConfig",
@@ -287,6 +295,7 @@ packageTargets.append(contentsOf: [
         name: "AwsCommonRuntimeKitTests",
         dependencies: ["AwsCommonRuntimeKit"],
         path: "Test/AwsCommonRuntimeKitTests",
+        exclude: awsCommonRuntimeKitTestsExcludes,
         resources: [
             .process("Resources")
         ]

--- a/Package.swift
+++ b/Package.swift
@@ -39,13 +39,19 @@ var awsCCommonPlatformExcludes = ["source/android",
 // includes arch/generic because the SwiftPM doesn't like the necessary compiler flags.
 awsCCommonPlatformExcludes.append("source/arch/intel")
 awsCCommonPlatformExcludes.append("source/arch/arm")
-#if !os(Windows)
+#if os(Windows)
+awsCCommonPlatformExcludes.append("source/posix")
+#else
 awsCCommonPlatformExcludes.append("source/windows")
 #endif
-let cSettingsCommon: [CSetting] = [
+
+var cSettingsCommon: [CSetting] = [
     .headerSearchPath("source/external/libcbor"),
     .define("DEBUG_BUILD", .when(configuration: .debug))
 ]
+#if os(Windows)
+cSettingsCommon.append(.define("AWS_OS_WINDOWS_DESKTOP"))
+#endif
 
 //////////////////////////////////////////////////////////////////////
 /// aws-c-cal
@@ -117,6 +123,8 @@ var cSettingsIO = cSettings
 #if os(Linux)
 ioDependencies.append("S2N_TLS")
 cSettingsIO.append(.define("USE_S2N"))
+#elseif os(Windows)
+cSettingsIO.append(.define("AWS_USE_IO_COMPLETION_PORTS"))
 #endif
 
 #if os(Windows)
@@ -124,6 +132,7 @@ awsCIoPlatformExcludes.append("source/posix")
 awsCIoPlatformExcludes.append("source/linux")
 awsCIoPlatformExcludes.append("source/s2n")
 awsCIoPlatformExcludes.append("source/darwin")
+awsCIoPlatformExcludes.append("source/bsd")
 #elseif os(Linux)
 awsCIoPlatformExcludes.append("source/windows")
 awsCIoPlatformExcludes.append("source/bsd")
@@ -145,9 +154,6 @@ var awsCChecksumsExcludes = [
     "README.md",
     "cmake",
     "tests"]
-
-// swift never uses Microsoft Visual C++ compiler
-awsCChecksumsExcludes.append("source/intel/visualc")
 
 // Hardware accelerated checksums are disabled because SwiftPM doesn't like the necessary compiler flags.
 // We can add it once SwiftPM has the necessary support for CPU flags or builds C libraries

--- a/Source/AwsCommonRuntimeKit/crt/Allocator.swift
+++ b/Source/AwsCommonRuntimeKit/crt/Allocator.swift
@@ -79,7 +79,7 @@ final class TracingAllocator: Allocator {
         self.rawValue = aws_mem_tracer_new(
             tracingAllocator.rawValue,
             nil,
-            aws_mem_trace_level(level.rawValue),
+            aws_mem_trace_level(Int32(level.rawValue)),
             framesPerStack)
     }
 

--- a/Source/AwsCommonRuntimeKit/event-stream/EventStreamHeader.swift
+++ b/Source/AwsCommonRuntimeKit/event-stream/EventStreamHeader.swift
@@ -4,6 +4,11 @@
 import AwsCEventStream
 import Foundation
 
+#if os(Windows)
+// Resolve ambiguity with the Windows SDK type.
+import struct Foundation.UUID
+#endif
+
 public struct EventStreamHeader {
     /// max header name length is 127 bytes (Int8.max)
     public static let maxNameLength = AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX

--- a/Source/AwsCommonRuntimeKit/io/StreamCore.swift
+++ b/Source/AwsCommonRuntimeKit/io/StreamCore.swift
@@ -42,7 +42,7 @@ private func doSeek(_ stream: UnsafeMutablePointer<aws_input_stream>!,
     let iStreamCore = Unmanaged<IStreamCore>.fromOpaque(stream.pointee.impl).takeUnretainedValue()
     let iStreamable = iStreamCore.iStreamable
     do {
-        let streamSeekType = StreamSeekType(rawValue: seekBasis.rawValue)!
+        let streamSeekType = StreamSeekType(rawValue: UInt32(seekBasis.rawValue))!
         try iStreamable.seek(offset: offset, streamSeekType: streamSeekType)
         iStreamCore.isEndOfStream = false
         return AWS_OP_SUCCESS

--- a/Source/AwsCommonRuntimeKit/io/TLSContextOptions.swift
+++ b/Source/AwsCommonRuntimeKit/io/TLSContextOptions.swift
@@ -124,7 +124,7 @@ public class TLSContextOptions: CStruct {
     }
 
     public func setMinimumTLSVersion(_ tlsVersion: TLSVersion) {
-        aws_tls_ctx_options_set_minimum_tls_version(rawValue, aws_tls_versions(rawValue: tlsVersion.rawValue))
+        aws_tls_ctx_options_set_minimum_tls_version(rawValue, aws_tls_versions(rawValue: Int32(tlsVersion.rawValue)))
     }
 
     typealias RawType = aws_tls_ctx_options

--- a/Test/AwsCommonRuntimeKitTests/XCBaseTestCase.swift
+++ b/Test/AwsCommonRuntimeKitTests/XCBaseTestCase.swift
@@ -61,6 +61,12 @@ extension XCTestCase {
         #endif
     }
 
+    func skipIfWindows() throws {
+        #if os(Windows)
+            throw XCTSkip("Skipping test on Windows")
+        #endif
+    }
+
     func skipIftvOS() throws {
         #if os(tvOS)
             throw XCTSkip("Skipping test on tvOS")

--- a/Test/AwsCommonRuntimeKitTests/sdkutils/FileBasedConfigurationTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/sdkutils/FileBasedConfigurationTests.swift
@@ -65,6 +65,8 @@ class FileBasedConfigurationTests: XCBaseTestCase {
     }
 
     func testResolveConfigPath() throws {
+        try skipIfWindows()
+
         // from $HOME
         let home = "/test/home"
         let oldHome = getenv("HOME")

--- a/Test/AwsCommonRuntimeKitTests/shims/windows/SetEnvShim.swift
+++ b/Test/AwsCommonRuntimeKitTests/shims/windows/SetEnvShim.swift
@@ -1,0 +1,21 @@
+import Foundation
+import WinSDK
+
+@discardableResult
+func setenv(_ name: String, _ value: String, _ overwrite: Int) -> Int {
+    let namePtr = name.withCString(encodedAs: UTF8.self) { $0 }
+    let valuePtr = value.withCString(encodedAs: UTF8.self) { $0 }
+    return SetEnvironmentVariableA(namePtr, valuePtr) ? 0 : -1
+}
+
+@discardableResult
+func setenv(_ name: String, _ value: LPCSTR, _ overwrite: Int) -> Int {
+    let namePtr = name.withCString(encodedAs: UTF8.self) { $0 }
+    return SetEnvironmentVariableA(namePtr, value) ? 0 : -1
+}
+
+@discardableResult
+func unsetenv(_ name: String) -> Int {
+    let namePtr = name.withCString(encodedAs: UTF8.self) { $0 }
+    return SetEnvironmentVariableA(namePtr, nil) ? 0 : -1
+}


### PR DESCRIPTION
*Issue #, if available:* #289

*Description of changes:*
* Add posix and bsd paths to excludes for Windows.
* Define `AWS_OS_WINDOWS_DESKTOP` and `AWS_USE_IO_COMPLETION_PORTS` for Windows.
* Fix some type casts between `Int32` <--> `UInt32` that cause errors on Windows.
* Remove non-existent exclude path (silences a useless warning).
* Explicitly use `Foundation.UUID` where needed to avoid confusion with Windows SDK `UUID`.
* Add `setenv`/`unsetenv` shim for tests on Windows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
