### PR TITLE
Fix STSCredentialsProvider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
       matrix:
         # This matrix runs tests on Mac, on oldest & newest supported Xcodes
         runner:
-          - macos-12 # x64
           - macos-13 # x64
           - macos-14
           - macos-13-xlarge
@@ -72,7 +71,6 @@ jobs:
       matrix:
         # This matrix runs tests on iOS, tvOS & watchOS, on oldest & newest supported Xcodes
         runner:
-          - macos-12 # x64
           - macos-13 # x64
           - macos-14
           - macos-13-xlarge
@@ -90,8 +88,6 @@ jobs:
         exclude:
           # Don't run old macOS with new Xcode
           - runner: macos-13-xlarge
-            xcode: Xcode_15.2
-          - runner: macos-12
             xcode: Xcode_15.2
           - runner: macos-13
             xcode: Xcode_15.2

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CredentialsProvider.swift
@@ -483,11 +483,11 @@ extension CredentialsProvider.Source {
         Self {
             let shutdownCallbackCore = ShutdownCallbackCore(shutdownCallback)
             var stsOptions = aws_credentials_provider_sts_options()
+            stsOptions.bootstrap = bootstrap.rawValue;
             stsOptions.tls_ctx = tlsContext.rawValue
             stsOptions.creds_provider = credentialsProvider.rawValue
             stsOptions.duration_seconds = UInt16(duration)
             stsOptions.shutdown_options = shutdownCallbackCore.getRetainedCredentialProviderShutdownOptions()
-            stsOptions.bootstrap = bootstrap.rawValue;
 
             guard let provider: UnsafeMutablePointer<aws_credentials_provider> = withByteCursorFromStrings(
                     roleArn,

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CredentialsProvider.swift
@@ -483,7 +483,7 @@ extension CredentialsProvider.Source {
         Self {
             let shutdownCallbackCore = ShutdownCallbackCore(shutdownCallback)
             var stsOptions = aws_credentials_provider_sts_options()
-            stsOptions.bootstrap = bootstrap.rawValue;
+            stsOptions.bootstrap = bootstrap.rawValue
             stsOptions.tls_ctx = tlsContext.rawValue
             stsOptions.creds_provider = credentialsProvider.rawValue
             stsOptions.duration_seconds = UInt16(duration)

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CredentialsProvider.swift
@@ -487,6 +487,7 @@ extension CredentialsProvider.Source {
             stsOptions.creds_provider = credentialsProvider.rawValue
             stsOptions.duration_seconds = UInt16(duration)
             stsOptions.shutdown_options = shutdownCallbackCore.getRetainedCredentialProviderShutdownOptions()
+            stsOptions.bootstrap = bootstrap.rawValue;
 
             guard let provider: UnsafeMutablePointer<aws_credentials_provider> = withByteCursorFromStrings(
                     roleArn,

--- a/Test/AwsCommonRuntimeKitTests/auth/CredentialsProviderTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/auth/CredentialsProviderTests.swift
@@ -221,17 +221,17 @@ class CredentialsProviderTests: XCBaseTestCase {
                 tokenFilePath: "tokenFilePath"))
     }
 
-    func testCreateDestroyStsInvalidRole() async throws {
+    func testCreateDestroySts() async throws {
         let provider = try CredentialsProvider(source: .static(accessKey: accessKey,
                 secret: secret,
                 sessionToken: sessionToken))
-        XCTAssertThrowsError(try CredentialsProvider(source: .sts(bootstrap: getClientBootstrap(),
+        _ = try CredentialsProvider(source: .sts(bootstrap: getClientBootstrap(),
                 tlsContext: getTlsContext(),
                 credentialsProvider: provider,
-                roleArn: "invalid-role-arn",
+                roleArn: "roleArn",
                 sessionName: "test-session",
                 duration: 10,
-                shutdownCallback: getShutdownCallback())))
+                shutdownCallback: getShutdownCallback()))
     }
 
     func testCreateDestroyEcsMissingCreds() async throws {


### PR DESCRIPTION
- Fix sts provider
- Remove macos-12 runner since it's deprecated https://github.com/actions/runner-images/issues/10721
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
