### PR TITLE
feat: Add support for accountId field on Credentials & CredentialsProvider

### DIFF
--- a/Source/AwsCommonRuntimeKit/auth/credentials/Credentials.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/Credentials.swift
@@ -8,9 +8,13 @@ public final class Credentials {
 
     let rawValue: OpaquePointer
 
-    init(rawValue: OpaquePointer) {
+    // TODO: remove this property once aws-c-auth supports account_id
+    private let accountId: String?
+
+    init(rawValue: OpaquePointer, accountId: String? = nil) {
         self.rawValue = rawValue
         aws_credentials_acquire(rawValue)
+        self.accountId = accountId
     }
 
     /// Creates a new set of aws credentials
@@ -19,12 +23,14 @@ public final class Credentials {
     ///   - accessKey: value for the aws access key id field
     ///   - secret: value for the secret access key field
     ///   - sessionToken: (Optional) security token associated with the credentials
+    ///   - accountId: (Optional) the account ID for the resolved credentials, if known
     ///   - expiration: (Optional) Point in time after which credentials will no longer be valid.
     ///                 For credentials that do not expire, use nil.
     ///                 If expiration.timeIntervalSince1970 is greater than UInt64.max, it will be converted to nil.
     /// - Throws: CommonRuntimeError.crtError
     public init(accessKey: String,
                 secret: String,
+                accountId: String? = nil,
                 sessionToken: String? = nil,
                 expiration: Date? = nil) throws {
 
@@ -51,6 +57,7 @@ public final class Credentials {
             throw CommonRunTimeError.crtError(.makeFromLastError())
         }
         self.rawValue = rawValue
+        self.accountId = accountId
     }
 
     /// Gets the access key from the `aws_credentials` instance
@@ -67,6 +74,15 @@ public final class Credentials {
     public func getSecret() -> String? {
         let secret = aws_credentials_get_secret_access_key(rawValue)
         return secret.toOptionalString()
+    }
+
+    /// Gets the account ID from the `Credentials`, if any.
+    ///
+    /// Temporarily, `accountId` is backed by a Swift instance variable.
+    /// In the future, when the C implementation implements `account_id` the implementation will get account ID from the `aws_credentials` instance.
+    /// - Returns:`String?`: The AWS Secret or nil
+    public func getAccountId() -> String? {
+        accountId
     }
 
     /// Gets the session token from the `aws_credentials` instance

--- a/Source/AwsCommonRuntimeKit/auth/credentials/Credentials.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/Credentials.swift
@@ -80,7 +80,7 @@ public final class Credentials {
     ///
     /// Temporarily, `accountId` is backed by a Swift instance variable.
     /// In the future, when the C implementation implements `account_id` the implementation will get account ID from the `aws_credentials` instance.
-    /// - Returns:`String?`: The AWS Secret or nil
+    /// - Returns:`String?`: The AWS `accountId` or nil
     public func getAccountId() -> String? {
         accountId
     }

--- a/Source/AwsCommonRuntimeKit/auth/credentials/CredentialsProvider.swift
+++ b/Source/AwsCommonRuntimeKit/auth/credentials/CredentialsProvider.swift
@@ -29,7 +29,10 @@ public class CredentialsProvider: CredentialsProviding {
     /// - Throws: CommonRuntimeError.crtError
     public func getCredentials() async throws -> Credentials {
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Credentials, Error>) in
-            let continuationCore = ContinuationCore(continuation: continuation, userData: ["accountId": accountId as Any])
+            let continuationCore = ContinuationCore(
+                continuation: continuation,
+                userData: ["accountId": accountId as Any]
+            )
             if aws_credentials_provider_get_credentials(rawValue,
                                                         onGetCredentials,
                                                         continuationCore.passRetained()) != AWS_OP_SUCCESS {

--- a/Source/AwsCommonRuntimeKit/crt/ContinuationCore.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ContinuationCore.swift
@@ -1,13 +1,17 @@
 //  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  SPDX-License-Identifier: Apache-2.0.
 
+// TODO: Remove userData property once it is no longer needed for accountId on credentials
+
 /// Core classes have manual memory management.
 /// You have to balance the retain & release calls in all cases to avoid leaking memory.
 class ContinuationCore<T> {
     let continuation: CheckedContinuation<T, Error>
+    let userData: [String: Any]?
 
-    init(continuation: CheckedContinuation<T, Error>) {
+    init(continuation: CheckedContinuation<T, Error>, userData: [String: Any]? = nil) {
         self.continuation = continuation
+        self.userData = userData
     }
 
     func passRetained() -> UnsafeMutableRawPointer {

--- a/Test/AwsCommonRuntimeKitTests/auth/CredentialsProviderTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/auth/CredentialsProviderTests.swift
@@ -2,11 +2,12 @@
 //  SPDX-License-Identifier: Apache-2.0.
 
 import XCTest
-@testable import AwsCommonRuntimeKit
+@_spi(AccountIDTempSupport) @testable import AwsCommonRuntimeKit
 
 class CredentialsProviderTests: XCBaseTestCase {
     let accessKey = "AccessKey"
     let secret = "Sekrit"
+    var accountId: String? = nil
     let sessionToken = "Token"
 
     let shutdownWasCalled = XCTestExpectation(description: "Shutdown callback was called")
@@ -68,12 +69,14 @@ class CredentialsProviderTests: XCBaseTestCase {
         wait(for: [shutdownWasCalled], timeout: 15)
     }
 
+        // TODO: change this test to not pass accountId separately once the source function handles it
     func testCreateCredentialsProviderStatic() async throws {
+        accountId = "0123456789"
         do {
             let provider = try CredentialsProvider(source: .static(accessKey: accessKey,
                     secret: secret,
                     sessionToken: sessionToken,
-                    shutdownCallback: getShutdownCallback()))
+                    shutdownCallback: getShutdownCallback()), accountId: accountId)
             let credentials = try await provider.getCredentials()
             XCTAssertNotNil(credentials)
             assertCredentials(credentials: credentials)

--- a/Test/AwsCommonRuntimeKitTests/auth/CredentialsTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/auth/CredentialsTests.swift
@@ -8,13 +8,15 @@ class CredentialsTests: XCBaseTestCase {
     func testCreateAWSCredentials() async throws {
         let accessKey = "AccessKey"
         let secret = "Secret"
+        let accountId = "0123456789"
         let sessionToken = "Token"
         let expiration = Date(timeIntervalSinceNow: 10)
 
-        let credentials = try Credentials(accessKey: accessKey, secret: secret, sessionToken: sessionToken, expiration: expiration)
+        let credentials = try Credentials(accessKey: accessKey, secret: secret, accountId: accountId, sessionToken: sessionToken, expiration: expiration)
 
         XCTAssertEqual(accessKey, credentials.getAccessKey())
         XCTAssertEqual(secret, credentials.getSecret())
+        XCTAssertEqual(accountId, credentials.getAccountId())
         XCTAssertEqual(sessionToken, credentials.getSessionToken())
         XCTAssertEqual(UInt64(expiration.timeIntervalSince1970), UInt64(credentials.getExpiration()!.timeIntervalSince1970))
 
@@ -36,6 +38,22 @@ class CredentialsTests: XCBaseTestCase {
         let expiration2 = Date(timeIntervalSince1970: (Double) (UInt64.max)+10)
         let credentials2 = try Credentials(accessKey: accessKey, secret: secret, sessionToken: sessionToken, expiration: expiration2)
         XCTAssertNil(credentials2.getExpiration())
+    }
+
+    func testCreateAWSCredentialsWithoutAccountId() async throws {
+        let accessKey = "AccessKey"
+        let secret = "Secret"
+        let sessionToken = "Token"
+        let expiration = Date(timeIntervalSinceNow: 10)
+
+        let credentials = try Credentials(accessKey: accessKey, secret: secret, accountId: nil, sessionToken: sessionToken, expiration: expiration)
+
+        XCTAssertEqual(accessKey, credentials.getAccessKey())
+        XCTAssertEqual(secret, credentials.getSecret())
+        XCTAssertNil(credentials.getAccountId())
+        XCTAssertEqual(sessionToken, credentials.getSessionToken())
+        XCTAssertEqual(UInt64(expiration.timeIntervalSince1970), UInt64(credentials.getExpiration()!.timeIntervalSince1970))
+
     }
 
     func testCreateAWSCredentialsWithoutSessionToken() async throws {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- An optional-String `accountId` field is added to the `Credentials` type
- The `CredentialsProvider` is modified to allow for creation with an optional-param account ID
- Tests for credentials & credentials providers are modified to verify operation of the account ID field.

These changes are intended to be temporary.  A new public API for passing account ID into `CredentialsProvider` at creation is protected with `@_spi()` so that customers do not rely on it for permanent use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
