### PR TITLE
Make Mqtt5 client callbacks synchronous

### DIFF
--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
@@ -267,8 +267,7 @@ public class Mqtt5ClientCore {
         try self.rwlock.read {
             // Validate close() has not been called on client.
             guard let rawValue = self.rawValue else {
-                throw CommonRunTimeError.crtError(
-                    CRTError(code: AWS_CRT_SWIFT_MQTT_CLIENT_CLOSED.rawValue))
+                throw CommonRunTimeError.crtError(CRTError(code: AWS_CRT_SWIFT_MQTT_CLIENT_CLOSED.rawValue))
             }
             let errorCode = aws_mqtt5_client_start(rawValue)
 
@@ -290,8 +289,7 @@ public class Mqtt5ClientCore {
         try self.rwlock.read {
             // Validate close() has not been called on client.
             guard let rawValue = self.rawValue else {
-                throw CommonRunTimeError.crtError(
-                    CRTError(code: AWS_CRT_SWIFT_MQTT_CLIENT_CLOSED.rawValue))
+                throw CommonRunTimeError.crtError(CRTError(code: AWS_CRT_SWIFT_MQTT_CLIENT_CLOSED.rawValue))
             }
 
             var errorCode: Int32 = 0
@@ -406,10 +404,9 @@ public class Mqtt5ClientCore {
                     guard let rawValue = self.rawValue else {
                         continuationCore.release()
                         return continuation.resume(throwing: CommonRunTimeError.crtError(
-                                CRTError(code: AWS_ERROR_INVALID_ARGUMENT.rawValue, context: "Mqtt client is closed.")))
+                            CRTError(code: AWS_ERROR_INVALID_ARGUMENT.rawValue, context: "Mqtt client is closed.")))
                     }
-                    let result = aws_mqtt5_client_unsubscribe(
-                        rawValue, unsubscribePacketPointer, &callbackOptions)
+                    let result = aws_mqtt5_client_unsubscribe(rawValue, unsubscribePacketPointer, &callbackOptions)
                     guard result == AWS_OP_SUCCESS else {
                         continuationCore.release()
                         return continuation.resume(throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
@@ -432,16 +429,11 @@ public class Mqtt5ClientCore {
 }
 
 /// Handles lifecycle events from native Mqtt Client
-internal func MqttClientHandleLifecycleEvent(
-    _ lifecycleEvent: UnsafePointer<aws_mqtt5_client_lifecycle_event>?
-) {
+internal func MqttClientHandleLifecycleEvent(_ lifecycleEvent: UnsafePointer<aws_mqtt5_client_lifecycle_event>?) {
 
     guard let lifecycleEvent: UnsafePointer<aws_mqtt5_client_lifecycle_event> = lifecycleEvent,
-        let userData = lifecycleEvent.pointee.user_data
-    else {
-        fatalError(
-            "MqttClientLifecycleEvents was called from native without an aws_mqtt5_client_lifecycle_event."
-        )
+        let userData = lifecycleEvent.pointee.user_data else {
+        fatalError("MqttClientLifecycleEvents was called from native without an aws_mqtt5_client_lifecycle_event.")
     }
     let clientCore = Unmanaged<Mqtt5ClientCore>.fromOpaque(userData).takeUnretainedValue()
     let crtError = CRTError(code: lifecycleEvent.pointee.error_code)
@@ -508,8 +500,7 @@ internal func MqttClientHandleLifecycleEvent(
 
 internal func MqttClientHandlePublishRecieved(
     _ publish: UnsafePointer<aws_mqtt5_packet_publish_view>?,
-    _ user_data: UnsafeMutableRawPointer?
-) {
+    _ user_data: UnsafeMutableRawPointer?) {
     let clientCore = Unmanaged<Mqtt5ClientCore>.fromOpaque(user_data!).takeUnretainedValue()
 
     // validate the callback flag, if flag is false, return
@@ -529,8 +520,7 @@ internal func MqttClientWebsocketTransform(
     _ request: OpaquePointer?,
     _ user_data: UnsafeMutableRawPointer?,
     _ complete_fn: (@convention(c) (OpaquePointer?, Int32, UnsafeMutableRawPointer?) -> Void)?,
-    _ complete_ctx: UnsafeMutableRawPointer?
-) {
+    _ complete_ctx: UnsafeMutableRawPointer?) {
 
     let clientCore = Unmanaged<Mqtt5ClientCore>.fromOpaque(user_data!).takeUnretainedValue()
 
@@ -562,13 +552,10 @@ internal func MqttClientTerminationCallback(_ userData: UnsafeMutableRawPointer?
 }
 
 /// The completion callback to invoke when subscribe operation completes in native
-private func subscribeCompletionCallback(
-    suback: UnsafePointer<aws_mqtt5_packet_suback_view>?,
-    error_code: Int32,
-    complete_ctx: UnsafeMutableRawPointer?
-) {
-    let continuationCore = Unmanaged<ContinuationCore<SubackPacket>>.fromOpaque(complete_ctx!)
-        .takeRetainedValue()
+private func subscribeCompletionCallback(suback: UnsafePointer<aws_mqtt5_packet_suback_view>?,
+                                         error_code: Int32,
+                                         complete_ctx: UnsafeMutableRawPointer?) {
+    let continuationCore = Unmanaged<ContinuationCore<SubackPacket>>.fromOpaque(complete_ctx!).takeRetainedValue()
 
     guard error_code == AWS_OP_SUCCESS else {
         return continuationCore.continuation.resume(
@@ -604,8 +591,7 @@ private func publishCompletionCallback(packet_type: aws_mqtt5_packet_type,
             let puback = packet?.assumingMemoryBound(
                 to: aws_mqtt5_packet_puback_view.self)
         else {
-            return continuationCore.continuation.resume(
-                throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
+            return continuationCore.continuation.resume(throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
         }
         let publishResult = PublishResult(puback: PubackPacket(puback))
         return continuationCore.continuation.resume(returning: publishResult)
@@ -620,8 +606,7 @@ private func publishCompletionCallback(packet_type: aws_mqtt5_packet_type,
 private func unsubscribeCompletionCallback(unsuback: UnsafePointer<aws_mqtt5_packet_unsuback_view>?,
                                            error_code: Int32,
                                            complete_ctx: UnsafeMutableRawPointer?) {
-    let continuationCore = Unmanaged<ContinuationCore<UnsubackPacket>>.fromOpaque(complete_ctx!)
-        .takeRetainedValue()
+    let continuationCore = Unmanaged<ContinuationCore<UnsubackPacket>>.fromOpaque(complete_ctx!).takeRetainedValue()
 
     guard error_code == AWS_OP_SUCCESS else {
         return continuationCore.continuation.resume(throwing: CommonRunTimeError.crtError(CRTError(code: error_code)))

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
@@ -558,8 +558,7 @@ private func subscribeCompletionCallback(suback: UnsafePointer<aws_mqtt5_packet_
     let continuationCore = Unmanaged<ContinuationCore<SubackPacket>>.fromOpaque(complete_ctx!).takeRetainedValue()
 
     guard error_code == AWS_OP_SUCCESS else {
-        return continuationCore.continuation.resume(
-            throwing: CommonRunTimeError.crtError(CRTError(code: error_code)))
+        return continuationCore.continuation.resume(throwing: CommonRunTimeError.crtError(CRTError(code: error_code)))
     }
 
     if let suback {
@@ -574,24 +573,21 @@ private func publishCompletionCallback(packet_type: aws_mqtt5_packet_type,
                                        packet: UnsafeRawPointer?,
                                        error_code: Int32,
                                        complete_ctx: UnsafeMutableRawPointer?) {
-    let continuationCore = Unmanaged<ContinuationCore<PublishResult>>.fromOpaque(complete_ctx!)
-        .takeRetainedValue()
+    let continuationCore = Unmanaged<ContinuationCore<PublishResult>>.fromOpaque(complete_ctx!).takeRetainedValue()
 
     if error_code != AWS_OP_SUCCESS {
-        return continuationCore.continuation.resume(
-            throwing: CommonRunTimeError.crtError(CRTError(code: error_code)))
+        return continuationCore.continuation.resume(throwing: CommonRunTimeError.crtError(CRTError(code: error_code)))
     }
 
     switch packet_type {
-    case AWS_MQTT5_PT_NONE:  // QoS0
+    case AWS_MQTT5_PT_NONE:     // QoS0
         return continuationCore.continuation.resume(returning: PublishResult())
 
-    case AWS_MQTT5_PT_PUBACK:  // QoS1
-        guard
-            let puback = packet?.assumingMemoryBound(
-                to: aws_mqtt5_packet_puback_view.self)
-        else {
-            return continuationCore.continuation.resume(throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
+    case AWS_MQTT5_PT_PUBACK:   // QoS1
+        guard let puback = packet?.assumingMemoryBound(
+                to: aws_mqtt5_packet_puback_view.self) else {
+            return continuationCore.continuation.resume(
+                throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
         }
         let publishResult = PublishResult(puback: PubackPacket(puback))
         return continuationCore.continuation.resume(returning: publishResult)

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
@@ -22,10 +22,10 @@ public class ClientOperationStatistics {
     /// Total packet size of operations that have been sent to the server and are waiting for a corresponding ACK before they can be completed.
     public let unackedOperationSize: UInt64
 
-    public init(incompleteOperationCount: UInt64,
-                incompleteOperationSize: UInt64,
-                unackedOperationCount: UInt64,
-                unackedOperationSize: UInt64) {
+    public init (incompleteOperationCount: UInt64,
+                 incompleteOperationSize: UInt64,
+                 unackedOperationCount: UInt64,
+                 unackedOperationSize: UInt64) {
         self.incompleteOperationCount = incompleteOperationCount
         self.incompleteOperationSize = incompleteOperationSize
         self.unackedOperationCount = unackedOperationCount
@@ -59,7 +59,7 @@ public class LifecycleConnectionSuccessData {
     /// Mqtt behavior settings that have been dynamically negotiated as part of the CONNECT/CONNACK exchange.
     public let negotiatedSettings: NegotiatedSettings
 
-    public init(connackPacket: ConnackPacket, negotiatedSettings: NegotiatedSettings) {
+    public init (connackPacket: ConnackPacket, negotiatedSettings: NegotiatedSettings) {
         self.connackPacket = connackPacket
         self.negotiatedSettings = negotiatedSettings
     }
@@ -74,7 +74,7 @@ public class LifecycleConnectionFailureData {
     /// Data model of an `MQTT5 CONNACK <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901074>`_ packet.
     public let connackPacket: ConnackPacket?
 
-    public init(crtError: CRTError, connackPacket: ConnackPacket? = nil) {
+    public init (crtError: CRTError, connackPacket: ConnackPacket? = nil) {
         self.crtError = crtError
         self.connackPacket = connackPacket
     }
@@ -89,7 +89,7 @@ public class LifecycleDisconnectData {
     /// Data model of an `MQTT5 DISCONNECT <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901205>`_ packet.
     public let disconnectPacket: DisconnectPacket?
 
-    public init(crtError: CRTError, disconnectPacket: DisconnectPacket? = nil) {
+    public init (crtError: CRTError, disconnectPacket: DisconnectPacket? = nil) {
         self.crtError = crtError
         self.disconnectPacket = disconnectPacket
     }
@@ -125,9 +125,7 @@ public typealias OnWebSocketHandshakeInterceptComplete = (HTTPRequestBase, Int32
 /// such as signing/authorization etc... Returning from this function does not continue the websocket
 /// handshake since some work flows may be asynchronous. To accommodate that, onComplete must be invoked upon
 /// completion of the signing process.
-public typealias OnWebSocketHandshakeIntercept = @Sendable (
-    HTTPRequest, @escaping OnWebSocketHandshakeInterceptComplete
-) async -> Void
+public typealias OnWebSocketHandshakeIntercept = @Sendable (HTTPRequest, @escaping OnWebSocketHandshakeInterceptComplete) async -> Void
 
 // MARK: - Mqtt5 Client
 public class Mqtt5Client {
@@ -243,24 +241,16 @@ public class Mqtt5ClientCore {
 
         self.onPublishReceivedCallback = clientOptions.onPublishReceivedFn ?? { (_) in }
         self.onLifecycleEventStoppedCallback = clientOptions.onLifecycleEventStoppedFn ?? { (_) in }
-        self.onLifecycleEventAttemptingConnect =
-            clientOptions.onLifecycleEventAttemptingConnectFn ?? { (_) in }
-        self.onLifecycleEventConnectionSuccess =
-            clientOptions.onLifecycleEventConnectionSuccessFn ?? { (_) in }
-        self.onLifecycleEventConnectionFailure =
-            clientOptions.onLifecycleEventConnectionFailureFn ?? { (_) in }
-        self.onLifecycleEventDisconnection =
-            clientOptions.onLifecycleEventDisconnectionFn ?? { (_) in }
+        self.onLifecycleEventAttemptingConnect = clientOptions.onLifecycleEventAttemptingConnectFn ?? { (_) in }
+        self.onLifecycleEventConnectionSuccess = clientOptions.onLifecycleEventConnectionSuccessFn ?? { (_) in }
+        self.onLifecycleEventConnectionFailure = clientOptions.onLifecycleEventConnectionFailureFn ?? { (_) in }
+        self.onLifecycleEventDisconnection = clientOptions.onLifecycleEventDisconnectionFn ?? { (_) in }
         self.onWebsocketInterceptor = clientOptions.onWebsocketTransform
 
-        guard
-            let rawValue =
-                (clientOptions.withCPointer(
-                    userData: Unmanaged<Mqtt5ClientCore>.passRetained(self).toOpaque()
-                ) { optionsPointer in
-                    return aws_mqtt5_client_new(allocator.rawValue, optionsPointer)
-                })
-        else {
+        guard let rawValue = (clientOptions.withCPointer(
+            userData: Unmanaged<Mqtt5ClientCore>.passRetained(self).toOpaque()) { optionsPointer in
+            return aws_mqtt5_client_new(allocator.rawValue, optionsPointer)
+        }) else {
             // failed to create client, release the callback core
             Unmanaged<Mqtt5ClientCore>.passUnretained(self).release()
             throw CommonRunTimeError.crtError(.makeFromLastError())

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
@@ -249,12 +249,12 @@ public class Mqtt5ClientCore {
 
         guard let rawValue = (clientOptions.withCPointer(
             userData: Unmanaged<Mqtt5ClientCore>.passRetained(self).toOpaque()) { optionsPointer in
-            return aws_mqtt5_client_new(allocator.rawValue, optionsPointer)
-        }) else {
-            // failed to create client, release the callback core
-            Unmanaged<Mqtt5ClientCore>.passUnretained(self).release()
-            throw CommonRunTimeError.crtError(.makeFromLastError())
-        }
+                    return aws_mqtt5_client_new(allocator.rawValue, optionsPointer)
+                }) else {
+                    // failed to create client, release the callback core
+                    Unmanaged<Mqtt5ClientCore>.passUnretained(self).release()
+                    throw CommonRunTimeError.crtError(.makeFromLastError())
+                }
         self.rawValue = rawValue
     }
 
@@ -332,16 +332,13 @@ public class Mqtt5ClientCore {
                     // Validate close() has not been called on client.
                     guard let rawValue = self.rawValue else {
                         continuationCore.release()
-                        return continuation.resume(
-                            throwing: CommonRunTimeError.crtError(
-                                CRTError(code: AWS_CRT_SWIFT_MQTT_CLIENT_CLOSED.rawValue)))
+                        return continuation.resume(throwing: CommonRunTimeError.crtError(CRTError(code: AWS_CRT_SWIFT_MQTT_CLIENT_CLOSED.rawValue)))
                     }
                     let result = aws_mqtt5_client_subscribe(
                         rawValue, subscribePacketPointer, &callbackOptions)
                     guard result == AWS_OP_SUCCESS else {
                         continuationCore.release()
-                        return continuation.resume(
-                            throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
+                        return continuation.resume(throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
                     }
                 }
             }
@@ -595,12 +592,10 @@ private func subscribeCompletionCallback(
 }
 
 /// The completion callback to invoke when publish operation completes in native
-private func publishCompletionCallback(
-    packet_type: aws_mqtt5_packet_type,
-    packet: UnsafeRawPointer?,
-    error_code: Int32,
-    complete_ctx: UnsafeMutableRawPointer?
-) {
+private func publishCompletionCallback(packet_type: aws_mqtt5_packet_type,
+                                       packet: UnsafeRawPointer?,
+                                       error_code: Int32,
+                                       complete_ctx: UnsafeMutableRawPointer?) {
     let continuationCore = Unmanaged<ContinuationCore<PublishResult>>.fromOpaque(complete_ctx!)
         .takeRetainedValue()
 
@@ -631,17 +626,14 @@ private func publishCompletionCallback(
 }
 
 /// The completion callback to invoke when unsubscribe operation completes in native
-private func unsubscribeCompletionCallback(
-    unsuback: UnsafePointer<aws_mqtt5_packet_unsuback_view>?,
-    error_code: Int32,
-    complete_ctx: UnsafeMutableRawPointer?
-) {
+private func unsubscribeCompletionCallback(unsuback: UnsafePointer<aws_mqtt5_packet_unsuback_view>?,
+                                           error_code: Int32,
+                                           complete_ctx: UnsafeMutableRawPointer?) {
     let continuationCore = Unmanaged<ContinuationCore<UnsubackPacket>>.fromOpaque(complete_ctx!)
         .takeRetainedValue()
 
     guard error_code == AWS_OP_SUCCESS else {
-        return continuationCore.continuation.resume(
-            throwing: CommonRunTimeError.crtError(CRTError(code: error_code)))
+        return continuationCore.continuation.resume(throwing: CommonRunTimeError.crtError(CRTError(code: error_code)))
     }
 
     if let unsuback {

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
@@ -125,7 +125,7 @@ public typealias OnWebSocketHandshakeInterceptComplete = (HTTPRequestBase, Int32
 /// such as signing/authorization etc... Returning from this function does not continue the websocket
 /// handshake since some work flows may be asynchronous. To accommodate that, onComplete must be invoked upon
 /// completion of the signing process.
-public typealias OnWebSocketHandshakeIntercept = @Sendable (HTTPRequest, @escaping OnWebSocketHandshakeInterceptComplete) async -> Void
+public typealias OnWebSocketHandshakeIntercept = @Sendable (HTTPRequest, @escaping OnWebSocketHandshakeInterceptComplete) -> Void
 
 // MARK: - Mqtt5 Client
 public class Mqtt5Client {
@@ -537,9 +537,7 @@ internal func MqttClientWebsocketTransform(
         }
 
         if clientCore.onWebsocketInterceptor != nil {
-            Task {
-                await clientCore.onWebsocketInterceptor!(httpRequest, signerTransform)
-            }
+            clientCore.onWebsocketInterceptor!(httpRequest, signerTransform)
         }
     }
 }
@@ -585,10 +583,10 @@ private func publishCompletionCallback(packet_type: aws_mqtt5_packet_type,
 
     case AWS_MQTT5_PT_PUBACK:   // QoS1
         guard let puback = packet?.assumingMemoryBound(
-                to: aws_mqtt5_packet_puback_view.self) else {
+            to: aws_mqtt5_packet_puback_view.self) else {
             return continuationCore.continuation.resume(
                 throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
-        }
+            }
         let publishResult = PublishResult(puback: PubackPacket(puback))
         return continuationCore.continuation.resume(returning: publishResult)
 

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
@@ -332,10 +332,10 @@ public class Mqtt5ClientCore {
                     // Validate close() has not been called on client.
                     guard let rawValue = self.rawValue else {
                         continuationCore.release()
-                        return continuation.resume(throwing: CommonRunTimeError.crtError(CRTError(code: AWS_CRT_SWIFT_MQTT_CLIENT_CLOSED.rawValue)))
+                        return continuation.resume(throwing: CommonRunTimeError.crtError(
+                            CRTError(code: AWS_CRT_SWIFT_MQTT_CLIENT_CLOSED.rawValue)))
                     }
-                    let result = aws_mqtt5_client_subscribe(
-                        rawValue, subscribePacketPointer, &callbackOptions)
+                    let result = aws_mqtt5_client_subscribe(rawValue, subscribePacketPointer, &callbackOptions)
                     guard result == AWS_OP_SUCCESS else {
                         continuationCore.release()
                         return continuation.resume(throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
@@ -370,19 +370,14 @@ public class Mqtt5ClientCore {
                     // Validate close() has not been called on client.
                     guard let rawValue = self.rawValue else {
                         continuationCore.release()
-                        return continuation.resume(
-                            throwing: CommonRunTimeError.crtError(
-                                CRTError(
-                                    code: AWS_ERROR_INVALID_ARGUMENT.rawValue,
-                                    context: "Mqtt client is closed.")))
+                        return continuation.resume(throwing: CommonRunTimeError.crtError(
+                            CRTError(code: AWS_ERROR_INVALID_ARGUMENT.rawValue, context: "Mqtt client is closed.")))
                     }
 
-                    let result = aws_mqtt5_client_publish(
-                        rawValue, publishPacketPointer, &callbackOptions)
+                    let result = aws_mqtt5_client_publish(rawValue, publishPacketPointer, &callbackOptions)
                     if result != AWS_OP_SUCCESS {
                         continuationCore.release()
-                        return continuation.resume(
-                            throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
+                        return continuation.resume(throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
                     }
                 }
             }
@@ -410,18 +405,14 @@ public class Mqtt5ClientCore {
                     // Validate close() has not been called on client.
                     guard let rawValue = self.rawValue else {
                         continuationCore.release()
-                        return continuation.resume(
-                            throwing: CommonRunTimeError.crtError(
-                                CRTError(
-                                    code: AWS_ERROR_INVALID_ARGUMENT.rawValue,
-                                    context: "Mqtt client is closed.")))
+                        return continuation.resume(throwing: CommonRunTimeError.crtError(
+                                CRTError(code: AWS_ERROR_INVALID_ARGUMENT.rawValue, context: "Mqtt client is closed.")))
                     }
                     let result = aws_mqtt5_client_unsubscribe(
                         rawValue, unsubscribePacketPointer, &callbackOptions)
                     guard result == AWS_OP_SUCCESS else {
                         continuationCore.release()
-                        return continuation.resume(
-                            throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
+                        return continuation.resume(throwing: CommonRunTimeError.crtError(CRTError.makeFromLastError()))
                     }
                 }
             }

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Client.swift
@@ -22,12 +22,10 @@ public class ClientOperationStatistics {
     /// Total packet size of operations that have been sent to the server and are waiting for a corresponding ACK before they can be completed.
     public let unackedOperationSize: UInt64
 
-    public init(
-        incompleteOperationCount: UInt64,
-        incompleteOperationSize: UInt64,
-        unackedOperationCount: UInt64,
-        unackedOperationSize: UInt64
-    ) {
+    public init(incompleteOperationCount: UInt64,
+                incompleteOperationSize: UInt64,
+                unackedOperationCount: UInt64,
+                unackedOperationSize: UInt64) {
         self.incompleteOperationCount = incompleteOperationCount
         self.incompleteOperationSize = incompleteOperationSize
         self.unackedOperationCount = unackedOperationCount
@@ -41,16 +39,16 @@ public class PublishReceivedData {
     /// Data model of an `MQTT5 PUBLISH <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901100>`_ packet.
     public let publishPacket: PublishPacket
 
-    public init(publishPacket: PublishPacket) {
+    public init (publishPacket: PublishPacket) {
         self.publishPacket = publishPacket
     }
 }
 
 /// Class containing results of an Stopped Lifecycle Event. Currently unused.
-public class LifecycleStoppedData {}
+public class LifecycleStoppedData { }
 
 /// Class containing results of an Attempting Connect Lifecycle Event. Currently unused.
-public class LifecycleAttemptingConnectData {}
+public class LifecycleAttemptingConnectData { }
 
 /// Class containing results of a Connect Success Lifecycle Event.
 public class LifecycleConnectionSuccessData {
@@ -512,9 +510,7 @@ internal func MqttClientHandleLifecycleEvent(
 
             var disconnectPacket: DisconnectPacket?
 
-            if let disconnectView: UnsafePointer<aws_mqtt5_packet_disconnect_view> = lifecycleEvent
-                .pointee.disconnect_data
-            {
+            if let disconnectView: UnsafePointer<aws_mqtt5_packet_disconnect_view> = lifecycleEvent.pointee.disconnect_data {
                 disconnectPacket = DisconnectPacket(disconnectView)
             }
 

--- a/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
@@ -648,17 +648,15 @@ class Mqtt5ClientTests: XCBaseTestCase {
 
             // We manually setup the websocket transform to avoid recursive reference between provider and test context
             let onWebsocketTransform : OnWebSocketHandshakeIntercept = { httpRequest, completCallback in
-                do
-                {
-                    let returnedHttpRequest = try await Signer.signRequest(request: httpRequest, config:signingConfig)
-                    completCallback(returnedHttpRequest, AWS_OP_SUCCESS)
-                }
-                catch CommonRunTimeError.crtError (let error) {
-                    completCallback(httpRequest, Int32(error.code))
-                }
-                catch
-                {
-                    completCallback(httpRequest, Int32(AWS_ERROR_UNSUPPORTED_OPERATION.rawValue))
+                Task {
+                    do {
+                        let returnedHttpRequest = try await Signer.signRequest(request: httpRequest, config:signingConfig)
+                        completCallback(returnedHttpRequest, AWS_OP_SUCCESS)
+                    } catch CommonRunTimeError.crtError (let error) {
+                        completCallback(httpRequest, Int32(error.code))
+                    } catch {
+                        completCallback(httpRequest, Int32(AWS_ERROR_UNSUPPORTED_OPERATION.rawValue))
+                    }
                 }
             }
 
@@ -730,17 +728,15 @@ class Mqtt5ClientTests: XCBaseTestCase {
 
         // We manually setup the websocket transform to avoid recursive reference between provider and test context
         let onWebsocketTransform : OnWebSocketHandshakeIntercept = { httpRequest, completCallback in
-            do
-            {
-                let returnedHttpRequest = try await Signer.signRequest(request: httpRequest, config:signingConfig)
-                completCallback(returnedHttpRequest, AWS_OP_SUCCESS)
-            }
-            catch CommonRunTimeError.crtError (let error) {
-                completCallback(httpRequest, Int32(error.code))
-            }
-            catch
-            {
-                completCallback(httpRequest, Int32(AWS_ERROR_UNSUPPORTED_OPERATION.rawValue))
+            Task {
+                do {
+                    let returnedHttpRequest = try await Signer.signRequest(request: httpRequest, config:signingConfig)
+                    completCallback(returnedHttpRequest, AWS_OP_SUCCESS)
+                } catch CommonRunTimeError.crtError (let error) {
+                    completCallback(httpRequest, Int32(error.code))
+                } catch {
+                    completCallback(httpRequest, Int32(AWS_ERROR_UNSUPPORTED_OPERATION.rawValue))
+                }
             }
         }
 
@@ -850,20 +846,18 @@ class Mqtt5ClientTests: XCBaseTestCase {
                                               omitSessionToken: true)
 
             let onWebsocketTransform : OnWebSocketHandshakeIntercept = { httpRequest, completCallback in
-                do
-                {
-                    let returnedHttpRequest = try await Signer.signRequest(request: httpRequest, config:signingConfig)
-                    completCallback(returnedHttpRequest, AWS_OP_SUCCESS)
-                    print("complete signing")
-                }
-                catch CommonRunTimeError.crtError (let error) {
-                    completCallback(httpRequest, Int32(error.code))
-                    print("signing failed with crterror")
-                }
-                catch
-                {
-                    completCallback(httpRequest, Int32(AWS_ERROR_UNSUPPORTED_OPERATION.rawValue))
-                    print("signing failed")
+                Task {
+                    do {
+                        let returnedHttpRequest = try await Signer.signRequest(request: httpRequest, config:signingConfig)
+                        completCallback(returnedHttpRequest, AWS_OP_SUCCESS)
+                        print("complete signing")
+                    } catch CommonRunTimeError.crtError (let error) {
+                        completCallback(httpRequest, Int32(error.code))
+                        print("signing failed with crterror")
+                    } catch {
+                        completCallback(httpRequest, Int32(AWS_ERROR_UNSUPPORTED_OPERATION.rawValue))
+                        print("signing failed")
+                    }
                 }
             }
 


### PR DESCRIPTION
Removed `async` from all callback type-aliases for the MQTT5 client. Instead of being scheduled in their own task block for execution, they will now be handled directly on the CRT I/O thread (eventloop).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
