### PR TITLE
Fix ByteBuffer End of Stream Bug 

### DIFF
--- a/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
@@ -71,6 +71,6 @@ extension ByteBuffer: IStreamable {
     }
     
     public func isEndOfStream() -> Bool {
-        return self.currentIndex >= self.data.count
+        self.currentIndex >= self.data.endIndex
     }
 }

--- a/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
+++ b/Source/AwsCommonRuntimeKit/crt/ByteBuffer.swift
@@ -71,6 +71,6 @@ extension ByteBuffer: IStreamable {
     }
     
     public func isEndOfStream() -> Bool {
-        self.currentIndex >= self.data.endIndex
+        return self.currentIndex >= self.data.endIndex
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Data.startIndex doesn't start with 0 if the Data is a slice in a larger portion. Use endIndex instead. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
