### PR TITLE
Fix Flaky Tests

### DIFF
--- a/Test/AwsCommonRuntimeKitTests/http/HTTP2ClientConnectionTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/http/HTTP2ClientConnectionTests.swift
@@ -6,7 +6,7 @@ import XCTest
 class HTTP2ClientConnectionTests: XCBaseTestCase {
 
     let expectedVersion = HTTPVersion.version_2
-    let host = "https://postman-echo.com"
+    let host = "postman-echo.com"
     
     func testGetHTTP2RequestVersion() async throws {
         let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: host, alpnList: ["h2","http/1.1"])
@@ -76,7 +76,7 @@ class HTTP2ClientConnectionTests: XCBaseTestCase {
                 method: "GET",
                 endpoint: host,
                 path: "/delete",
-                expectedStatus: 405,
+                expectedStatus: 404,
                 connectionManager: connectionManager,
                 expectedVersion: expectedVersion,
                 requestVersion: .version_2)
@@ -99,7 +99,7 @@ class HTTP2ClientConnectionTests: XCBaseTestCase {
                 method: "GET",
                 endpoint: host,
                 path: "/delete",
-                expectedStatus: 405,
+                expectedStatus: 404,
                 connectionManager: connectionManager,
                 expectedVersion: expectedVersion,
                 requestVersion: .version_1_1)

--- a/Test/AwsCommonRuntimeKitTests/http/HTTP2ClientConnectionTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/http/HTTP2ClientConnectionTests.swift
@@ -6,16 +6,17 @@ import XCTest
 class HTTP2ClientConnectionTests: XCBaseTestCase {
 
     let expectedVersion = HTTPVersion.version_2
-
+    let host = "https://postman-echo.com"
+    
     func testGetHTTP2RequestVersion() async throws {
-        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: "httpbin.org", alpnList: ["h2","http/1.1"])
+        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: host, alpnList: ["h2","http/1.1"])
         let connection = try await connectionManager.acquireConnection()
         XCTAssertEqual(connection.httpVersion, HTTPVersion.version_2)
     }
 
     // Test that the binding works not the actual functionality. C part has tests for functionality
     func testHTTP2UpdateSetting() async throws {
-        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: "httpbin.org", alpnList: ["h2","http/1.1"])
+        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: host, alpnList: ["h2","http/1.1"])
         let connection = try await connectionManager.acquireConnection()
         if let connection = connection as? HTTP2ClientConnection {
             try await connection.updateSetting(setting: HTTP2Settings(enablePush: false))
@@ -26,7 +27,7 @@ class HTTP2ClientConnectionTests: XCBaseTestCase {
 
     // Test that the binding works not the actual functionality. C part has tests for functionality
     func testHTTP2UpdateSettingEmpty() async throws {
-        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: "httpbin.org", alpnList: ["h2","http/1.1"])
+        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: host, alpnList: ["h2","http/1.1"])
         let connection = try await connectionManager.acquireConnection()
         if let connection = connection as? HTTP2ClientConnection {
             try await connection.updateSetting(setting: HTTP2Settings())
@@ -37,7 +38,7 @@ class HTTP2ClientConnectionTests: XCBaseTestCase {
 
     // Test that the binding works not the actual functionality. C part has tests for functionality
     func testHTTP2SendPing() async throws {
-        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: "httpbin.org", alpnList: ["h2","http/1.1"])
+        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: host, alpnList: ["h2","http/1.1"])
         let connection = try await connectionManager.acquireConnection()
         if let connection = connection as? HTTP2ClientConnection {
             var time = try await connection.sendPing()
@@ -51,7 +52,7 @@ class HTTP2ClientConnectionTests: XCBaseTestCase {
 
     // Test that the binding works not the actual functionality. C part has tests for functionality
     func testHTTP2SendGoAway() async throws {
-        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: "httpbin.org", alpnList: ["h2","http/1.1"])
+        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: host, alpnList: ["h2","http/1.1"])
         let connection = try await connectionManager.acquireConnection()
         if let connection = connection as? HTTP2ClientConnection {
           connection.sendGoAway(error: .internalError, allowMoreStreams: false)
@@ -61,10 +62,10 @@ class HTTP2ClientConnectionTests: XCBaseTestCase {
     }
 
     func testGetHttpsRequest() async throws {
-        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: "httpbin.org", alpnList: ["h2","http/1.1"])
+        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: host, alpnList: ["h2","http/1.1"])
         let response = try await HTTPClientTestFixture.sendHTTPRequest(
                 method: "GET",
-                endpoint: "httpbin.org",
+                endpoint: host,
                 path: "/get",
                 connectionManager: connectionManager,
                 expectedVersion: expectedVersion,
@@ -73,7 +74,7 @@ class HTTP2ClientConnectionTests: XCBaseTestCase {
         XCTAssertEqual(response.headers[0].name, ":status")
         let response2 = try await HTTPClientTestFixture.sendHTTPRequest(
                 method: "GET",
-                endpoint: "httpbin.org",
+                endpoint: host,
                 path: "/delete",
                 expectedStatus: 405,
                 connectionManager: connectionManager,
@@ -84,10 +85,10 @@ class HTTP2ClientConnectionTests: XCBaseTestCase {
 
 
     func testGetHttpsRequestWithHTTP1_1Request() async throws {
-        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: "httpbin.org", alpnList: ["h2","http/1.1"])
+        let connectionManager = try await HTTPClientTestFixture.getHttpConnectionManager(endpoint: host, alpnList: ["h2","http/1.1"])
         let response = try await HTTPClientTestFixture.sendHTTPRequest(
                 method: "GET",
-                endpoint: "httpbin.org",
+                endpoint: host,
                 path: "/get",
                 connectionManager: connectionManager,
                 expectedVersion: expectedVersion,
@@ -96,7 +97,7 @@ class HTTP2ClientConnectionTests: XCBaseTestCase {
         XCTAssertEqual(response.headers[0].name, ":status")
         let response2 = try await HTTPClientTestFixture.sendHTTPRequest(
                 method: "GET",
-                endpoint: "httpbin.org",
+                endpoint: host,
                 path: "/delete",
                 expectedStatus: 405,
                 connectionManager: connectionManager,

--- a/Test/AwsCommonRuntimeKitTests/http/HTTP2StreamManagerTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/http/HTTP2StreamManagerTests.swift
@@ -7,7 +7,8 @@ import XCTest
 class HTT2StreamManagerTests: XCBaseTestCase {
     let endpoint = "d1cz66xoahf9cl.cloudfront.net"; // Use cloudfront for HTTP/2
     let path = "/random_32_byte.data";
-
+    let host = "nghttp2.org"
+    
     func testStreamManagerCreate() throws {
         let tlsContextOptions = TLSContextOptions()
         let tlsContext = try TLSContext(options: tlsContextOptions, mode: .client)
@@ -106,7 +107,7 @@ class HTT2StreamManagerTests: XCBaseTestCase {
     }
 
     func testHTTP2StreamUpload() async throws {
-        let streamManager = try makeStreamManger(host: "nghttp2.org")
+        let streamManager = try makeStreamManger(host: host)
         let semaphore = TestSemaphore(value: 0)
         var httpResponse = HTTPResponse()
         var onCompleteCalled = false
@@ -170,7 +171,7 @@ class HTT2StreamManagerTests: XCBaseTestCase {
     }
 
     func testHTTP2ParallelStreams(count: Int) async throws {
-        let streamManager = try makeStreamManger(host: "nghttp2.org")
+        let streamManager = try makeStreamManger(host: host)
         return await withTaskGroup(of: Void.self) { taskGroup in
             for _ in 1...count {
                 taskGroup.addTask {

--- a/Test/AwsCommonRuntimeKitTests/io/StreamTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/io/StreamTests.swift
@@ -1,13 +1,21 @@
+import Foundation
 //  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  SPDX-License-Identifier: Apache-2.0.
 import XCTest
-import Foundation
+
 @testable import AwsCommonRuntimeKit
 
 class StreamTests: XCBaseTestCase {
 
   func testByteBufferStream() throws {
     let byteBuffer = ByteBuffer(data: "12345678900987654321".data(using: .utf8)!)
+    let iStreamCore = IStreamCore(iStreamable: byteBuffer)
+    try testStream(iStreamCore: iStreamCore)
+  }
+
+  func testByteBufferEndOfStream() throws {
+    let data = "1234567890098765432112345678900987654321".data(using: .utf8)!
+    let byteBuffer = ByteBuffer(data: data[20...])
     let iStreamCore = IStreamCore(iStreamable: byteBuffer)
     try testStream(iStreamCore: iStreamCore)
   }
@@ -21,25 +29,30 @@ class StreamTests: XCBaseTestCase {
     }
 
     XCTAssertEqual(20, try iStreamCore.iStreamable.length())
+    XCTAssertFalse(iStreamCore.iStreamable.isEndOfStream())
 
     var length = try iStreamCore.iStreamable.read(buffer: buffer)
     XCTAssertEqual(length, capacity)
     XCTAssertEqual(String(bytes: buffer, encoding: .utf8), "1234567890")
+    XCTAssertFalse(iStreamCore.iStreamable.isEndOfStream())
 
     length = try iStreamCore.iStreamable.read(buffer: buffer)
     XCTAssertEqual(length, capacity)
     XCTAssertEqual(String(bytes: buffer, encoding: .utf8), "0987654321")
+    XCTAssertTrue(iStreamCore.iStreamable.isEndOfStream())
 
     length = try iStreamCore.iStreamable.read(buffer: buffer)
     XCTAssertEqual(length, nil)
 
-
     try iStreamCore.iStreamable.seek(offset: 0, streamSeekType: StreamSeekType.begin)
+    XCTAssertFalse(iStreamCore.iStreamable.isEndOfStream())
     length = try iStreamCore.iStreamable.read(buffer: buffer)
     XCTAssertEqual(length, capacity)
     XCTAssertEqual(String(bytes: buffer, encoding: .utf8), "1234567890")
+    XCTAssertFalse(iStreamCore.iStreamable.isEndOfStream())
 
     try iStreamCore.iStreamable.seek(offset: 10, streamSeekType: StreamSeekType.begin)
+    XCTAssertFalse(iStreamCore.iStreamable.isEndOfStream())
 
     let largeBuffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 100)
     defer {
@@ -49,12 +62,15 @@ class StreamTests: XCBaseTestCase {
     length = try iStreamCore.iStreamable.read(buffer: largeBuffer)
     XCTAssertEqual(length, capacity)
     XCTAssertEqual(String(bytes: largeBuffer[..<length!], encoding: .utf8), "0987654321")
+    XCTAssertTrue(iStreamCore.iStreamable.isEndOfStream())
 
     length = try iStreamCore.iStreamable.read(buffer: largeBuffer)
     XCTAssertEqual(length, nil)
 
     length = try iStreamCore.iStreamable.read(buffer: largeBuffer)
     XCTAssertEqual(length, nil)
+
+    XCTAssertTrue(iStreamCore.iStreamable.isEndOfStream())
   }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- httpbin.org is flaky and abandoned. Move to postman-echo.com. Similar to https://github.com/awslabs/aws-crt-java/pull/627
- Add a test for isEndOfStream. This is a follow up from #334.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
