### PR TITLE
IoT Metrics Implementation

### DIFF
--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -7,6 +7,9 @@ import LibNative
 /// `CommonRuntimeKit.initialize` must be called before using any other functionality.
 public struct CommonRuntimeKit {
 
+  /// The current version of the AWS Common Runtime Kit.
+  public static let CRTVersion = "1.0.0"
+
   /// Initializes the library.
   /// Must be called before using any other functionality.
   public static func initialize() {

--- a/Source/AwsCommonRuntimeKit/io/TLSContext.swift
+++ b/Source/AwsCommonRuntimeKit/io/TLSContext.swift
@@ -6,7 +6,11 @@ import AwsCIo
 public class TLSContext {
   var rawValue: UnsafeMutablePointer<aws_tls_ctx>
 
+  /// The minimum TLS version that was configured, if any. Used for metrics tracking.
+  public let minimumTLSVersion: TLSVersion?
+
   public init(options: TLSContextOptions, mode: TLSMode) throws {
+    self.minimumTLSVersion = options.minimumTLSVersion
     guard
       let rawValue =
         (options.withCPointer { optionsPointer -> UnsafeMutablePointer<aws_tls_ctx>? in

--- a/Source/AwsCommonRuntimeKit/io/TLSContextOptions.swift
+++ b/Source/AwsCommonRuntimeKit/io/TLSContextOptions.swift
@@ -8,6 +8,9 @@ import struct Foundation.Data
 public class TLSContextOptions: CStruct {
   private var rawValue: UnsafeMutablePointer<aws_tls_ctx_options>
 
+  /// track minimum tls version set by user
+  public private(set) var minimumTLSVersion: TLSVersion?
+
   public static func makeDefault() -> TLSContextOptions {
     TLSContextOptions()
   }
@@ -175,6 +178,7 @@ public class TLSContextOptions: CStruct {
   }
 
   public func setMinimumTLSVersion(_ tlsVersion: TLSVersion) {
+    self.minimumTLSVersion = tlsVersion
     aws_tls_ctx_options_set_minimum_tls_version(
       rawValue, aws_tls_versions(rawValue: tlsVersion.rawValue))
   }

--- a/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
@@ -1,0 +1,355 @@
+///  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+///  SPDX-License-Identifier: Apache-2.0.
+
+import AwsCMqtt
+import Foundation
+
+// MARK: - IoT Device SDK Metrics
+
+/// Configuration for the AWS IoT Device SDK Metrics.
+/// This structure is used to pass metrics configuration from the SDK layer through the CRT to aws-c-mqtt.
+///
+/// The metrics will be appended to the MQTT CONNECT packet's username field.
+public class IoTDeviceSDKMetrics: CStruct {
+  /// The library name identifier for the SDK (e.g., "IoTDeviceSDK/Swift")
+  /// This maps to the SDK attribute in the username field.
+  public let libraryName: String
+
+  /// Metadata dictionary for key-value pairs.
+  public var metadata: [String: String]
+
+  /// Default library name for Swift SDK
+  private static let defaultLibraryName = "IoTDeviceSDK/Swift"
+
+  /// Creates a new IoTDeviceSDKMetrics instance with default library name
+  public init() {
+    self.libraryName = IoTDeviceSDKMetrics.defaultLibraryName
+    self.metadata = [:]
+  }
+
+  /// Creates a new IoTDeviceSDKMetrics instance with a custom library name
+  /// - Parameter libraryName: The library name to use for metrics (nil uses default)
+  public init(libraryName: String?) {
+    self.libraryName = libraryName ?? IoTDeviceSDKMetrics.defaultLibraryName
+    self.metadata = [:]
+  }
+
+  /// Creates a new IoTDeviceSDKMetrics instance with library name and metadata
+  /// - Parameters:
+  ///   - libraryName: The library name to use for metrics
+  ///   - metadata: Dictionary of metadata key-value pairs
+  public init(libraryName: String, metadata: [String: String]) {
+    self.libraryName = libraryName
+    self.metadata = metadata
+  }
+
+  typealias RawType = aws_mqtt_iot_metrics
+  func withCStruct<Result>(_ body: (aws_mqtt_iot_metrics) -> Result) -> Result {
+
+    // TODO: need further support for metadata field
+    // Convert metadata dictionary to array of aws_mqtt_metadata_entry
+    var raw_metrics = aws_mqtt_iot_metrics()
+    return libraryName.withByteCursor { libraryNameByteCursor in
+      raw_metrics.library_name = libraryNameByteCursor
+      return body(raw_metrics)
+    }
+  }
+}
+
+// MARK: - Feature ID Constants (Package-Private)
+
+/// Feature IDs for IoT SDK metrics tracking.
+/// These IDs are used to encode feature usage in the metrics string.
+/// Feature IDs are assigned sequentially and are never reused to ensure historical data consistency.
+enum MetricsFeatureId {
+  static let retryJitterMode: Character = "A"
+  static let sessionBehavior: Character = "B"
+  static let offlineQueueBehavior: Character = "C"
+  static let outboundTopicAliasBehavior: Character = "D"
+  static let inboundTopicAliasBehavior: Character = "E"
+  static let protocolVersion: Character = "F"
+  static let socketImplementation: Character = "G"
+  static let httpProxyType: Character = "H"
+  static let certificateSource: Character = "I"
+  static let tlsCipherPreference: Character = "J"
+  static let minimumTlsVersion: Character = "K"
+}
+
+// MARK: - Feature Value Constants (Package-Private)
+// Only for values that don't map to existing SDK enums
+
+/// Protocol version values for metrics
+enum MetricsProtocolVersionValue {
+  static let mqtt311: Character = "3"
+  static let mqtt5: Character = "5"
+}
+
+/// Socket implementation values for metrics
+enum MetricsSocketImplementationValue {
+  static let posix: Character = "A"
+  static let winsock: Character = "B"
+  static let appleNetworkFramework: Character = "C"
+}
+
+/// HTTP proxy type values for metrics
+enum MetricsHttpProxyTypeValue {
+  static let http: Character = "A"
+  static let https: Character = "B"
+}
+
+
+// MARK: - Extension mappings from existing enums to metrics values (Package-Private)
+// Note: Default values return nil to be omitted from the encoded feature list (minimizes payload size)
+// Values: A=first option, B=second option, C=third option, etc.
+
+extension ExponentialBackoffJitterMode {
+  /// Converts to metrics value character.
+  /// Returns nil only for `.default` case to omit from encoded list.
+  internal var metricsValue: Character? {
+    switch self {
+    case .none: return "A"
+    case .full: return "B"
+    case .decorrelated: return "C"
+    case .default: return nil
+    }
+  }
+}
+
+extension ClientSessionBehaviorType {
+  /// Converts to metrics value character.
+  /// Returns nil only for `.default` case to omit from encoded list.
+  internal var metricsValue: Character? {
+    switch self {
+    case .clean: return "A"
+    case .rejoinPostSuccess: return "B"
+    case .rejoinAlways: return "C"
+    case .default: return nil
+    }
+  }
+}
+
+extension ClientOperationQueueBehaviorType {
+  /// Converts to metrics value character.
+  /// Returns nil only for `.default` case to omit from encoded list.
+  internal var metricsValue: Character? {
+    switch self {
+    case .failNonQos1PublishOnDisconnect: return "A"
+    case .failQos0PublishOnDisconnect: return "B"
+    case .failAllOnDisconnect: return "C"
+    case .default: return nil
+    }
+  }
+}
+
+extension OutboundTopicAliasBehaviorType {
+  /// Converts to metrics value character.
+  /// Returns nil only for `.defaultBehavior` case to omit from encoded list.
+  internal var metricsValue: Character? {
+    switch self {
+    case .manual: return "A"
+    case .lru: return "B"
+    case .disabled: return "C"
+    case .defaultBehavior: return nil
+    }
+  }
+}
+
+extension InboundTopicAliasBehaviorType {
+  /// Converts to metrics value character.
+  /// Returns nil only for `.default` case to omit from encoded list.
+  internal var metricsValue: Character? {
+    switch self {
+    case .enabled: return "A"
+    case .disabled: return "B"
+    case .default: return nil
+    }
+  }
+}
+
+extension TLSVersion {
+  /// Converts to metrics value character.
+  /// Returns nil for systemDefault to omit from encoded list.
+  internal var metricsValue: Character? {
+    switch self {
+    case .SSLv3: return "A"
+    case .TLSv1: return "B"
+    case .TLSv1_1: return "C"
+    case .TLSv1_2: return "D"
+    case .TLSv1_3: return "E"
+    case .systemDefault: return nil
+    }
+  }
+}
+
+// MARK: - Metrics Version Constant (Package-Private)
+
+/// The current version of the IoT SDK metrics format
+let ioTSDKMetricsFeatureVersion: Int = 1
+
+// MARK: - Feature List Encoding Helper (Package-Private)
+
+/// Helper struct for encoding feature lists from MqttClientOptions.
+/// This struct provides static methods to extract and encode metrics directly from client options.
+///
+/// Note: This struct is package-private and not accessible to external libraries.
+struct IoTSDKMetricsEncoder {
+
+  /// Creates the final IoTDeviceSDKMetrics from MqttClientOptions.
+  /// This function sets the metrics according to the following rules:
+  /// - libraryName: set to default SDK Name. If the libraryName field is set from options.metrics, overwrite the default value
+  /// - Metadata - CRTVersion: not modifiable by user, automatically set to CRT version
+  /// - Metadata - IoTSDKMetricsVersion: If set by options.metrics, validates whether the metrics version
+  ///   matches the library's metrics version and processes IoTSDKFeature
+  /// - Metadata - IoTSDKFeature: merge the CRT feature and the input feature if the metrics version matches
+  ///
+  /// - Parameter options: The MqttClientOptions to extract features from
+  /// - Returns: The final IoTDeviceSDKMetrics with all metadata set
+  static func createMetrics(from options: MqttClientOptions) -> IoTDeviceSDKMetrics {
+    // Determine the library name: use user-provided or default
+    let libraryName = options.metrics?.libraryName
+
+    let finalMetrics = IoTDeviceSDKMetrics(libraryName: libraryName)
+
+    // CRTVersion: not modifiable by user, automatically set
+    finalMetrics.metadata["CRTVersion"] = CommonRuntimeKit.CRTVersion
+
+    // Get CRT feature list from options
+    let crtFeatureList = getEncodedFeatureList(from: options)
+
+    // Check if user provided metrics with metadata
+    if let userMetrics = options.metrics, !userMetrics.metadata.isEmpty {
+      let userMetricsVersion = userMetrics.metadata["IoTSDKMetricsVersion"]
+      let userFeature = userMetrics.metadata["IoTSDKFeature"]
+
+      // Only merge if version matches; otherwise use CRT features directly
+      if let versionString = userMetricsVersion,
+        let userVersion = Int(versionString),
+        userVersion == ioTSDKMetricsFeatureVersion,
+        let userFeatureValue = userFeature,
+        !userFeatureValue.isEmpty
+      {
+        finalMetrics.metadata["IoTSDKFeature"] = mergeFeatureLists(
+          crtFeatures: crtFeatureList, userFeatures: userFeatureValue)
+      } else {
+        finalMetrics.metadata["IoTSDKFeature"] = crtFeatureList
+      }
+
+      // Copy other user metadata (excluding IoTSDKFeature, IoTSDKMetricsVersion, CRTVersion)
+      for (key, value) in userMetrics.metadata
+      where key != "IoTSDKFeature" && key != "IoTSDKMetricsVersion" && key != "CRTVersion" {
+        finalMetrics.metadata[key] = value
+      }
+    } else {
+      finalMetrics.metadata["IoTSDKFeature"] = crtFeatureList
+    }
+
+    // Always add the current metrics version
+    finalMetrics.metadata["IoTSDKMetricsVersion"] = String(ioTSDKMetricsFeatureVersion)
+
+    return finalMetrics
+  }
+
+  /// Merges CRT features with user-provided features.
+  /// User features take precedence for the same feature ID.
+  ///
+  /// - Parameters:
+  ///   - crtFeatures: The CRT-generated feature list string
+  ///   - userFeatures: The user-provided feature list string
+  /// - Returns: The merged feature list string
+  private static func mergeFeatureLists(crtFeatures: String, userFeatures: String) -> String {
+    // Parse CRT features into a dictionary
+    var featureDict: [Character: Character] = [:]
+    for feature in crtFeatures.split(separator: ",") {
+      let parts = feature.split(separator: "/")
+      if parts.count == 2, let featureId = parts[0].first, let value = parts[1].first {
+        featureDict[featureId] = value
+      }
+    }
+
+    // Parse user features and merge (user features take precedence)
+    for feature in userFeatures.split(separator: ",") {
+      let parts = feature.split(separator: "/")
+      if parts.count == 2, let featureId = parts[0].first, let value = parts[1].first {
+        featureDict[featureId] = value
+      }
+    }
+
+    // Convert back to string, sorted by feature ID
+    let sortedFeatures = featureDict.keys.sorted().map { featureId in
+      "\(featureId)/\(featureDict[featureId]!)"
+    }
+
+    return sortedFeatures.joined(separator: ",")
+  }
+
+  /// Generates the encoded feature list string for metrics directly from MqttClientOptions.
+  /// The format is ID/Value pairs separated by commas.
+  /// Example: "A/B,C/A" means Feature A (retry_jitter_mode) with value B (FULL),
+  ///          and Feature C (offline_queue_behavior) with value A (FAIL_NON_QOS1_PUBLISH_ON_DISCONNECT)
+  ///
+  /// - Parameter options: The MqttClientOptions to extract features from
+  /// - Returns: The encoded feature list string
+  static func getEncodedFeatureList(from options: MqttClientOptions) -> String {
+    var features: [String] = []
+
+    // A: retry_jitter_mode
+    if let value = options.retryJitterMode?.metricsValue {
+      features.append("\(MetricsFeatureId.retryJitterMode)/\(value)")
+    }
+
+    // B: session_behavior
+    if let value = options.sessionBehavior?.metricsValue {
+      features.append("\(MetricsFeatureId.sessionBehavior)/\(value)")
+    }
+
+    // C: offline_queue_behavior
+    if let value = options.offlineQueueBehavior?.metricsValue {
+      features.append("\(MetricsFeatureId.offlineQueueBehavior)/\(value)")
+    }
+
+    // D: outbound_topic_alias_behavior
+    if let value = options.topicAliasingOptions?.outboundBehavior?.metricsValue {
+      features.append("\(MetricsFeatureId.outboundTopicAliasBehavior)/\(value)")
+    }
+
+    // E: inbound_topic_alias_behavior
+    if let value = options.topicAliasingOptions?.inboundBehavior?.metricsValue {
+      features.append("\(MetricsFeatureId.inboundTopicAliasBehavior)/\(value)")
+    }
+
+    // F: protocol_version - MQTT5 is always used for Mqtt5Client
+    features.append("\(MetricsFeatureId.protocolVersion)/\(MetricsProtocolVersionValue.mqtt5)")
+
+    // G: socket_implementation - Detect based on platform
+    let socketImpl = detectSocketImplementation()
+    features.append("\(MetricsFeatureId.socketImplementation)/\(socketImpl)")
+
+    // H: http_proxy_type - Determine based on whether proxy uses TLS
+    if let proxyOptions = options.httpProxyOptions {
+      // If the proxy has TLS options configured, it's HTTPS; otherwise HTTP
+      let proxyType = proxyOptions.tlsOptions != nil ? MetricsHttpProxyTypeValue.https : MetricsHttpProxyTypeValue.http
+      features.append("\(MetricsFeatureId.httpProxyType)/\(proxyType)")
+    }
+
+    // I: certificate_source - Would need to be tracked from TLS context setup
+    // This is typically set at a higher SDK level, not directly available in MqttClientOptions
+
+    // J: tls_cipher_preference - Not directly accessible from TLSContext
+
+    // K: minimum_tls_version - Not directly accessible from TLSContext
+    // The minimum TLS version is set on TLSContextOptions but not stored/accessible from TLSContext
+
+    return features.joined(separator: ",")
+  }
+
+  /// Detects the socket implementation based on platform.
+  private static func detectSocketImplementation() -> Character {
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+      return MetricsSocketImplementationValue.appleNetworkFramework
+    #elseif os(Windows)
+      return MetricsSocketImplementationValue.winsock
+    #else
+      return MetricsSocketImplementationValue.posix
+    #endif
+  }
+}

--- a/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
@@ -1,8 +1,49 @@
 ///  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ///  SPDX-License-Identifier: Apache-2.0.
 
+import AwsCCommon
 import AwsCMqtt
 import Foundation
+
+// MARK: - Metadata Entry
+
+/// A key-value pair for IoT SDK metrics metadata.
+/// This class is used internally to convert Swift dictionary entries to C structures.
+class MetadataEntry: CStruct, @unchecked Sendable {
+
+  /// Metadata key
+  let key: String
+
+  /// Metadata value
+  let value: String
+
+  init(key: String, value: String) {
+    self.key = key
+    self.value = value
+
+    withByteCursorFromStrings(self.key, self.value) { cKeyCursor, cValueCursor in
+      aws_byte_buf_init_copy_from_cursor(&keyBuffer, allocator, cKeyCursor)
+      aws_byte_buf_init_copy_from_cursor(&valueBuffer, allocator, cValueCursor)
+    }
+  }
+
+  typealias RawType = aws_mqtt_metadata_entry
+  func withCStruct<Result>(_ body: (aws_mqtt_metadata_entry) -> Result) -> Result {
+    var rawEntry = aws_mqtt_metadata_entry()
+    rawEntry.key = aws_byte_cursor_from_buf(&keyBuffer)
+    rawEntry.value = aws_byte_cursor_from_buf(&valueBuffer)
+    return body(rawEntry)
+  }
+
+  // Keep memory of the buffer storage in the class, and release it on destruction
+  private var keyBuffer: aws_byte_buf = aws_byte_buf()
+  private var valueBuffer: aws_byte_buf = aws_byte_buf()
+
+  deinit {
+    aws_byte_buf_clean_up(&keyBuffer)
+    aws_byte_buf_clean_up(&valueBuffer)
+  }
+}
 
 // MARK: - IoT Device SDK Metrics
 
@@ -45,13 +86,19 @@ public class IoTDeviceSDKMetrics: CStruct {
 
   typealias RawType = aws_mqtt_iot_metrics
   func withCStruct<Result>(_ body: (aws_mqtt_iot_metrics) -> Result) -> Result {
-
-    // TODO: need further support for metadata field
-    // Convert metadata dictionary to array of aws_mqtt_metadata_entry
     var raw_metrics = aws_mqtt_iot_metrics()
+
+    // Convert metadata dictionary to array of MetadataEntry
+    let metadataEntries = metadata.map { MetadataEntry(key: $0.key, value: $0.value) }
+
     return libraryName.withByteCursor { libraryNameByteCursor in
       raw_metrics.library_name = libraryNameByteCursor
-      return body(raw_metrics)
+
+      return metadataEntries.withAWSArrayList { metadataPointer in
+        raw_metrics.metadata_count = metadataEntries.count
+        raw_metrics.metadata_entries = UnsafePointer<aws_mqtt_metadata_entry>(metadataPointer)
+        return body(raw_metrics)
+      }
     }
   }
 }

--- a/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
@@ -97,7 +97,6 @@ enum MetricsHttpProxyTypeValue {
   static let https: Character = "B"
 }
 
-
 // MARK: - Extension mappings from existing enums to metrics values (Package-Private)
 // Note: Default values return nil to be omitted from the encoded feature list (minimizes payload size)
 // Values: A=first option, B=second option, C=third option, etc.
@@ -242,7 +241,7 @@ struct IoTSDKMetricsEncoder {
       }
     } else {
       finalMetrics.metadata["IoTSDKFeature"] = mergeFeatureLists(
-          crtFeatures: crtFeatureList, userFeatures: "")
+        crtFeatures: crtFeatureList, userFeatures: "")
     }
 
     // Always add the current metrics version
@@ -308,11 +307,13 @@ struct IoTSDKMetricsEncoder {
     // H: http_proxy_type - Determine based on whether proxy uses TLS
     if let proxyOptions = options.httpProxyOptions {
       // If the proxy has TLS options configured, it's HTTPS; otherwise HTTP
-      let proxyType = proxyOptions.tlsOptions != nil ? MetricsHttpProxyTypeValue.https : MetricsHttpProxyTypeValue.http
+      let proxyType =
+        proxyOptions.tlsOptions != nil
+        ? MetricsHttpProxyTypeValue.https : MetricsHttpProxyTypeValue.http
       features.append("\(MetricsFeatureId.httpProxyType)/\(proxyType)")
     }
 
-    // I: certificate_source - Would need to be tracked from TLS context setup. This is set at a IoT SDK level, 
+    // I: certificate_source - Would need to be tracked from TLS context setup. This is set at a IoT SDK level,
     // not directly available in MqttClientOptions
 
     // J: tls_cipher_preference - CRT Swift current doesn't have cipher preference support, leave it out for now

--- a/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
@@ -291,24 +291,14 @@ struct IoTSDKMetricsEncoder {
   /// User features take precedence for the same feature ID.
   ///
   /// - Parameters:
-  ///   - crtFeatures: The CRT-generated feature list string
-  ///   - userFeatures: The user-provided feature list string (can be "(A/A,B/B)" or "A/A,B/B")
+  ///   - crtFeatures: The CRT-generated feature list string (e.g., "A/A,B/B")
+  ///   - userFeatures: The user-provided feature list string (e.g., "L/A,M/B")
   /// - Returns: The merged feature list string
   private static func mergeFeatureLists(crtFeatures: String, userFeatures: String) -> String {
 
-    // Strip parentheses from user features if present
-    var cleanedUserFeatures = userFeatures
-    if cleanedUserFeatures.hasPrefix("(") && cleanedUserFeatures.hasSuffix(")") {
-      cleanedUserFeatures = String(cleanedUserFeatures.dropFirst().dropLast())
-    }
-    var cleanedCrtFeatures = crtFeatures
-    if cleanedCrtFeatures.hasPrefix("(") && cleanedCrtFeatures.hasSuffix(")") {
-      cleanedCrtFeatures = String(cleanedCrtFeatures.dropFirst().dropLast())
-    }
-
     // Parse CRT features into a dictionary
     var featureDict: [Character: Character] = [:]
-    for feature in cleanedCrtFeatures.split(separator: ",") {
+    for feature in crtFeatures.split(separator: ",") {
       let parts = feature.split(separator: "/")
       if parts.count == 2, let featureId = parts[0].first, let value = parts[1].first {
         featureDict[featureId] = value
@@ -316,7 +306,7 @@ struct IoTSDKMetricsEncoder {
     }
 
     // Parse user features and merge (user features take precedence)
-    for feature in cleanedUserFeatures.split(separator: ",") {
+    for feature in userFeatures.split(separator: ",") {
       let parts = feature.split(separator: "/")
       if parts.count == 2, let featureId = parts[0].first, let value = parts[1].first {
         featureDict[featureId] = value
@@ -328,7 +318,7 @@ struct IoTSDKMetricsEncoder {
       "\(featureId)/\(featureDict[featureId]!)"
     }
 
-    return "(" + sortedFeatures.joined(separator: ",") + ")"
+    return sortedFeatures.joined(separator: ",")
   }
 
   /// Generates the encoded feature list string for metrics directly from MqttClientOptions.

--- a/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
@@ -231,7 +231,8 @@ struct IoTSDKMetricsEncoder {
         finalMetrics.metadata["IoTSDKFeature"] = mergeFeatureLists(
           crtFeatures: crtFeatureList, userFeatures: userFeatureValue)
       } else {
-        finalMetrics.metadata["IoTSDKFeature"] = crtFeatureList
+        finalMetrics.metadata["IoTSDKFeature"] = mergeFeatureLists(
+          crtFeatures: crtFeatureList, userFeatures: "")
       }
 
       // Copy other user metadata (excluding IoTSDKFeature, IoTSDKMetricsVersion, CRTVersion)
@@ -240,7 +241,8 @@ struct IoTSDKMetricsEncoder {
         finalMetrics.metadata[key] = value
       }
     } else {
-      finalMetrics.metadata["IoTSDKFeature"] = crtFeatureList
+      finalMetrics.metadata["IoTSDKFeature"] = mergeFeatureLists(
+          crtFeatures: crtFeatureList, userFeatures: "")
     }
 
     // Always add the current metrics version
@@ -257,29 +259,8 @@ struct IoTSDKMetricsEncoder {
   ///   - userFeatures: The user-provided feature list string
   /// - Returns: The merged feature list string
   private static func mergeFeatureLists(crtFeatures: String, userFeatures: String) -> String {
-    // Parse CRT features into a dictionary
-    var featureDict: [Character: Character] = [:]
-    for feature in crtFeatures.split(separator: ",") {
-      let parts = feature.split(separator: "/")
-      if parts.count == 2, let featureId = parts[0].first, let value = parts[1].first {
-        featureDict[featureId] = value
-      }
-    }
-
-    // Parse user features and merge (user features take precedence)
-    for feature in userFeatures.split(separator: ",") {
-      let parts = feature.split(separator: "/")
-      if parts.count == 2, let featureId = parts[0].first, let value = parts[1].first {
-        featureDict[featureId] = value
-      }
-    }
-
-    // Convert back to string, sorted by feature ID
-    let sortedFeatures = featureDict.keys.sorted().map { featureId in
-      "\(featureId)/\(featureDict[featureId]!)"
-    }
-
-    return sortedFeatures.joined(separator: ",")
+    // TODO: Merge crtFeatures and user Features, returned merged final string
+    return "()"
   }
 
   /// Generates the encoded feature list string for metrics directly from MqttClientOptions.
@@ -331,18 +312,18 @@ struct IoTSDKMetricsEncoder {
       features.append("\(MetricsFeatureId.httpProxyType)/\(proxyType)")
     }
 
-    // I: certificate_source - Would need to be tracked from TLS context setup
-    // This is typically set at a higher SDK level, not directly available in MqttClientOptions
+    // I: certificate_source - Would need to be tracked from TLS context setup. This is set at a IoT SDK level, 
+    // not directly available in MqttClientOptions
 
-    // J: tls_cipher_preference - Not directly accessible from TLSContext
+    // J: tls_cipher_preference - CRT Swift current doesn't have cipher preference support, leave it out for now
 
-    // K: minimum_tls_version - Not directly accessible from TLSContext
-    // The minimum TLS version is set on TLSContextOptions but not stored/accessible from TLSContext
+    // K: minimum_tls_version - The minimum TLS version is set on TLSContextOptions but not stored/accessible from TLSContext,
+    // will track from IoT SDK level
 
     return features.joined(separator: ",")
   }
 
-  /// Detects the socket implementation based on platform.
+  /// Help function to determine the socket implementation based on platform.
   private static func detectSocketImplementation() -> Character {
     #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
       return MetricsSocketImplementationValue.appleNetworkFramework

--- a/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
@@ -207,47 +207,37 @@ struct IoTSDKMetricsEncoder {
     // Determine the library name: use user-provided or default
     let libraryName = options.metrics?.libraryName
 
-    let finalMetrics = IoTDeviceSDKMetrics(libraryName: libraryName)
+    let resultMetrics = IoTDeviceSDKMetrics(libraryName: libraryName)
 
     // CRTVersion: not modifiable by user, automatically set
-    finalMetrics.metadata["CRTVersion"] = CommonRuntimeKit.CRTVersion
+    resultMetrics.metadata["CRTVersion"] = CommonRuntimeKit.CRTVersion
 
     // Get CRT feature list from options
     let crtFeatureList = getEncodedFeatureList(from: options)
+    var userFeatureString: String = ""
 
-    // Check if user provided metrics with metadata
-    if let userMetrics = options.metrics, !userMetrics.metadata.isEmpty {
-      let userMetricsVersion = userMetrics.metadata["IoTSDKMetricsVersion"]
-      let userFeature = userMetrics.metadata["IoTSDKFeature"]
+    if let userMetadata = options.metrics?.metadata {
 
-      // Only merge if version matches; otherwise use CRT features directly
-      if let versionString = userMetricsVersion,
-        let userVersion = Int(versionString),
-        userVersion == ioTSDKMetricsFeatureVersion,
-        let userFeatureValue = userFeature,
-        !userFeatureValue.isEmpty
+      if let userFeatureVersion = userMetadata["IoTSDKMetricsVersion"],
+        Int(userFeatureVersion) == ioTSDKMetricsFeatureVersion,
+        let userFeature = userMetadata["IoTSDKFeature"]
       {
-        finalMetrics.metadata["IoTSDKFeature"] = mergeFeatureLists(
-          crtFeatures: crtFeatureList, userFeatures: userFeatureValue)
-      } else {
-        finalMetrics.metadata["IoTSDKFeature"] = mergeFeatureLists(
-          crtFeatures: crtFeatureList, userFeatures: "")
+        userFeatureString = userFeature
       }
 
-      // Copy other user metadata (excluding IoTSDKFeature, IoTSDKMetricsVersion, CRTVersion)
-      for (key, value) in userMetrics.metadata
+      for (key, value) in userMetadata
       where key != "IoTSDKFeature" && key != "IoTSDKMetricsVersion" && key != "CRTVersion" {
-        finalMetrics.metadata[key] = value
+        resultMetrics.metadata[key] = value
       }
-    } else {
-      finalMetrics.metadata["IoTSDKFeature"] = mergeFeatureLists(
-        crtFeatures: crtFeatureList, userFeatures: "")
     }
 
-    // Always add the current metrics version
-    finalMetrics.metadata["IoTSDKMetricsVersion"] = String(ioTSDKMetricsFeatureVersion)
+    resultMetrics.metadata["IoTSDKFeature"] = mergeFeatureLists(
+      crtFeatures: crtFeatureList, userFeatures: userFeatureString)
 
-    return finalMetrics
+    // Always add the current metrics version
+    resultMetrics.metadata["IoTSDKMetricsVersion"] = String(ioTSDKMetricsFeatureVersion)
+
+    return resultMetrics
   }
 
   /// Merges CRT features with user-provided features.
@@ -255,11 +245,43 @@ struct IoTSDKMetricsEncoder {
   ///
   /// - Parameters:
   ///   - crtFeatures: The CRT-generated feature list string
-  ///   - userFeatures: The user-provided feature list string
+  ///   - userFeatures: The user-provided feature list string (can be "(A/A,B/B)" or "A/A,B/B")
   /// - Returns: The merged feature list string
   private static func mergeFeatureLists(crtFeatures: String, userFeatures: String) -> String {
-    // TODO: Merge crtFeatures and user Features, returned merged final string
-    return "()"
+
+    // Strip parentheses from user features if present
+    var cleanedUserFeatures = userFeatures
+    if cleanedUserFeatures.hasPrefix("(") && cleanedUserFeatures.hasSuffix(")") {
+      cleanedUserFeatures = String(cleanedUserFeatures.dropFirst().dropLast())
+    }
+    var cleanedCrtFeatures = crtFeatures
+    if cleanedCrtFeatures.hasPrefix("(") && cleanedCrtFeatures.hasSuffix(")") {
+      cleanedCrtFeatures = String(cleanedCrtFeatures.dropFirst().dropLast())
+    }
+
+    // Parse CRT features into a dictionary
+    var featureDict: [Character: Character] = [:]
+    for feature in cleanedCrtFeatures.split(separator: ",") {
+      let parts = feature.split(separator: "/")
+      if parts.count == 2, let featureId = parts[0].first, let value = parts[1].first {
+        featureDict[featureId] = value
+      }
+    }
+
+    // Parse user features and merge (user features take precedence)
+    for feature in cleanedUserFeatures.split(separator: ",") {
+      let parts = feature.split(separator: "/")
+      if parts.count == 2, let featureId = parts[0].first, let value = parts[1].first {
+        featureDict[featureId] = value
+      }
+    }
+
+    // Convert back to string, sorted by feature ID
+    let sortedFeatures = featureDict.keys.sorted().map { featureId in
+      "\(featureId)/\(featureDict[featureId]!)"
+    }
+
+    return "(" + sortedFeatures.joined(separator: ",") + ")"
   }
 
   /// Generates the encoded feature list string for metrics directly from MqttClientOptions.

--- a/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/IoTSDKMetrics.swift
@@ -387,8 +387,13 @@ struct IoTSDKMetricsEncoder {
 
     // J: tls_cipher_preference - CRT Swift current doesn't have cipher preference support, leave it out for now
 
-    // K: minimum_tls_version - The minimum TLS version is set on TLSContextOptions but not stored/accessible from TLSContext,
-    // will track from IoT SDK level
+    // K: minimum_tls_version - Get from TLSContext if available
+    if let tlsCtx = options.tlsCtx,
+      let minTlsVersion = tlsCtx.minimumTLSVersion,
+      let metricsValue = minTlsVersion.metricsValue
+    {
+      features.append("\(MetricsFeatureId.minimumTlsVersion)/\(metricsValue)")
+    }
 
     return features.joined(separator: ",")
   }

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
@@ -426,7 +426,7 @@ public class MqttClientOptions: CStructWithUserData {
     userData: UnsafeMutableRawPointer?, _ body: (aws_mqtt5_client_options) -> Result
   ) -> Result {
 
-    var finalMetrics = IoTSDKMetricsEncoder.createMetrics(from: self)
+    let finalMetrics = IoTSDKMetricsEncoder.createMetrics(from: self)
 
     var raw_options = aws_mqtt5_client_options()
 

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
@@ -201,7 +201,6 @@ public class MqttConnectOptions: CStruct {
   }
 }
 
-
 /// Configuration for the creation of MQTT5 clients
 public class MqttClientOptions: CStructWithUserData {
   /// Host name of the MQTT server to connect to.

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
@@ -425,7 +425,8 @@ public class MqttClientOptions: CStructWithUserData {
     userData: UnsafeMutableRawPointer?, _ body: (aws_mqtt5_client_options) -> Result
   ) -> Result {
 
-    let finalMetrics : IoTDeviceSDKMetrics? = self.disableMetrics ? nil : IoTSDKMetricsEncoder.createMetrics(from: self)
+    let finalMetrics: IoTDeviceSDKMetrics? =
+      self.disableMetrics ? nil : IoTSDKMetricsEncoder.createMetrics(from: self)
 
     var raw_options = aws_mqtt5_client_options()
 

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
@@ -278,7 +278,7 @@ public class MqttClientOptions: CStructWithUserData {
   /// Callback for Lifecycle Event Disconnection.
   public let onLifecycleEventDisconnectionFn: OnLifecycleEventDisconnection?
 
-  /// Enable AWS IoT Metrics, including SDK name, version, and platform. Default to True.
+  /// Disable AWS IoT Metrics, including SDK name, version, and platform. Default to True.
   public let disableMetrics: Bool
 
   /// AWS IoT SDK Metrics configuration. If disableMetrics is false/not set and this is nil, default metrics will be used.

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
@@ -201,20 +201,6 @@ public class MqttConnectOptions: CStruct {
   }
 }
 
-/// Configuration for the AWS IoT Metrics, including SDK name, version, and platforms.
-private class AwsIoTSDKMetrics: CStruct {
-  public let libraryName: String = "IoTDeviceSDK/Swift"
-
-  typealias RawType = aws_mqtt_iot_metrics
-  func withCStruct<Result>(_ body: (aws_mqtt_iot_metrics) -> Result) -> Result {
-    var raw_metrics = aws_mqtt_iot_metrics()
-    return libraryName.withByteCursor { libraryNameByteCursor in
-      raw_metrics.library_name = libraryNameByteCursor
-      return body(raw_metrics)
-    }
-  }
-
-}
 
 /// Configuration for the creation of MQTT5 clients
 public class MqttClientOptions: CStructWithUserData {
@@ -294,10 +280,11 @@ public class MqttClientOptions: CStructWithUserData {
   public let onLifecycleEventDisconnectionFn: OnLifecycleEventDisconnection?
 
   /// Enable AWS IoT Metrics, including SDK name, version, and platform. Default to True.
-  public let enableMetrics: Bool
+  public let disableMetrics: Bool
 
-  /// AWS IoT Metrics. This is internally set only.
-  private let metrics: AwsIoTSDKMetrics?
+  /// AWS IoT SDK Metrics configuration. If disableMetrics is false/not set and this is nil, default metrics will be used.
+  /// Users can provide custom metrics to override the default behavior.
+  public let metrics: IoTDeviceSDKMetrics?
 
   public init(
     hostName: String,
@@ -325,7 +312,8 @@ public class MqttClientOptions: CStructWithUserData {
     onLifecycleEventConnectionSuccessFn: OnLifecycleEventConnectionSuccess? = nil,
     onLifecycleEventConnectionFailureFn: OnLifecycleEventConnectionFailure? = nil,
     onLifecycleEventDisconnectionFn: OnLifecycleEventDisconnection? = nil,
-    enableMetrics: Bool = true
+    disableMetrics: Bool? = false,
+    metrics: IoTDeviceSDKMetrics? = nil
   ) {
 
     self.hostName = hostName
@@ -369,8 +357,8 @@ public class MqttClientOptions: CStructWithUserData {
     self.onLifecycleEventConnectionSuccessFn = onLifecycleEventConnectionSuccessFn
     self.onLifecycleEventConnectionFailureFn = onLifecycleEventConnectionFailureFn
     self.onLifecycleEventDisconnectionFn = onLifecycleEventDisconnectionFn
-    self.enableMetrics = enableMetrics
-    self.metrics = enableMetrics ? AwsIoTSDKMetrics() : nil
+    self.disableMetrics = disableMetrics ?? false
+    self.metrics = metrics
   }
 
   func validateConversionToNative() throws {
@@ -437,6 +425,9 @@ public class MqttClientOptions: CStructWithUserData {
   func withCStruct<Result>(
     userData: UnsafeMutableRawPointer?, _ body: (aws_mqtt5_client_options) -> Result
   ) -> Result {
+
+    var finalMetrics = IoTSDKMetricsEncoder.createMetrics(from: self)
+
     var raw_options = aws_mqtt5_client_options()
 
     raw_options.port = self.port
@@ -500,7 +491,7 @@ public class MqttClientOptions: CStructWithUserData {
       tls_options,
       self.httpProxyOptions,
       self.topicAliasingOptions,
-      self.metrics,
+      finalMetrics,
       connnectOptions
     ) {
       socketOptionsCPointer,

--- a/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
+++ b/Source/AwsCommonRuntimeKit/mqtt/Mqtt5Options.swift
@@ -425,7 +425,7 @@ public class MqttClientOptions: CStructWithUserData {
     userData: UnsafeMutableRawPointer?, _ body: (aws_mqtt5_client_options) -> Result
   ) -> Result {
 
-    let finalMetrics = IoTSDKMetricsEncoder.createMetrics(from: self)
+    let finalMetrics : IoTDeviceSDKMetrics? = self.disableMetrics ? nil : IoTSDKMetricsEncoder.createMetrics(from: self)
 
     var raw_options = aws_mqtt5_client_options()
 

--- a/Test/AwsCommonRuntimeKitTests/mqtt/IoTSDKMetricsTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/mqtt/IoTSDKMetricsTests.swift
@@ -1,0 +1,176 @@
+///  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+///  SPDX-License-Identifier: Apache-2.0.
+
+import XCTest
+@testable import AwsCommonRuntimeKit
+
+class IoTSDKMetricsTests: XCBaseTestCase {
+
+  // MARK: - Feature List Encoding Tests (Using IoTSDKMetricsEncoder)
+
+  func testMinimalOptionsEncoding() {
+    // Create options with minimal settings (all defaults)
+    let options = MqttClientOptions(
+      hostName: "test.example.com",
+      port: 8883
+    )
+
+    let encoded = IoTSDKMetricsEncoder.getEncodedFeatureList(from: options)
+
+    // Should always include protocol version (F/5 for MQTT5) and socket implementation
+    XCTAssertTrue(encoded.contains("F/5"))  // protocol_version = MQTT5
+    XCTAssertTrue(encoded.contains("G/"))  // socket_implementation (platform dependent)
+
+    // Default values should NOT be included
+    XCTAssertFalse(encoded.contains("A/"))  // retry_jitter_mode default (FULL) omitted
+    XCTAssertFalse(encoded.contains("B/"))  // session_behavior default (CLEAN) omitted
+    XCTAssertFalse(encoded.contains("C/"))  // offline_queue_behavior default omitted
+  }
+
+  func testOptionsWithMultipleNonDefaultFeaturesEncoding() {
+    let topicAliasing = TopicAliasingOptions()
+    topicAliasing.outboundBehavior = .lru  // Non-default (default is DISABLED)
+    topicAliasing.inboundBehavior = .enabled  // Non-default (default is DISABLED)
+
+    let options = MqttClientOptions(
+      hostName: "test.example.com",
+      port: 8883,
+      sessionBehavior: .rejoinAlways,  // Non-default (default is CLEAN)
+      offlineQueueBehavior: .failAllOnDisconnect,  // Non-default
+      retryJitterMode: .decorrelated,  // Non-default (default is FULL)
+      topicAliasingOptions: topicAliasing
+    )
+
+    let encoded = IoTSDKMetricsEncoder.getEncodedFeatureList(from: options)
+
+    // Verify each NON-DEFAULT feature is present with new ID/Value format
+    XCTAssertTrue(encoded.contains("A/C"))  // retry_jitter_mode = DECORRELATED (non-default)
+    XCTAssertTrue(encoded.contains("B/C"))  // session_behavior = REJOIN_ALWAYS (non-default)
+    XCTAssertTrue(encoded.contains("C/C"))  // offline_queue_behavior = FAIL_ALL_ON_DISCONNECT (non-default)
+    XCTAssertTrue(encoded.contains("D/B"))  // outbound_topic_alias_behavior = LRU (non-default)
+    XCTAssertTrue(encoded.contains("E/A"))  // inbound_topic_alias_behavior = ENABLED (non-default)
+    XCTAssertTrue(encoded.contains("F/5"))  // protocol_version = MQTT5
+
+    // Verify the format is comma-separated
+    let features = encoded.split(separator: ",")
+    XCTAssertGreaterThanOrEqual(features.count, 6)
+  }
+
+  // MARK: - createMetrics Tests
+
+  func testCreateMetricsWithDefaultOptions() {
+    let options = MqttClientOptions(
+      hostName: "test.example.com",
+      port: 8883,
+      sessionBehavior: .clean
+    )
+
+    let metrics = IoTSDKMetricsEncoder.createMetrics(from: options)
+
+    // Should have default library name
+    XCTAssertEqual(metrics.libraryName, "IoTDeviceSDK/Swift")
+
+    // Should have CRTVersion, IoTSDKFeature, and IoTSDKMetricsVersion
+    XCTAssertEqual(metrics.metadata["CRTVersion"], CommonRuntimeKit.CRTVersion)
+
+    let featureList = metrics.metadata["IoTSDKFeature"]
+    XCTAssertNotNil(featureList)
+    XCTAssertTrue(featureList!.contains("F/5"))  // MQTT5
+
+    XCTAssertEqual(metrics.metadata["IoTSDKMetricsVersion"], "1")
+  }
+
+  func testCreateMetricsWithUserFeaturesMerged() {
+    let customMetrics = IoTDeviceSDKMetrics(libraryName: "CustomSDK/Test")
+    customMetrics.metadata["IoTSDKMetricsVersion"] = "1"
+    customMetrics.metadata["IoTSDKFeature"] = "(L/A,M/B)"  // Custom features with parentheses
+
+    let options = MqttClientOptions(
+      hostName: "test.example.com",
+      port: 8883,
+      sessionBehavior: .clean,
+      metrics: customMetrics
+    )
+
+    let metrics = IoTSDKMetricsEncoder.createMetrics(from: options)
+
+    // Should use custom library name
+    XCTAssertEqual(metrics.libraryName, "CustomSDK/Test")
+
+    // Should have merged features
+    let featureList = metrics.metadata["IoTSDKFeature"]
+    XCTAssertNotNil(featureList)
+
+    // Should contain CRT features (F/5, G/C, B/A)
+    XCTAssertTrue(featureList!.contains("F/5"))  // MQTT5
+    XCTAssertTrue(featureList!.contains("B/A"))  // session_behavior = CLEAN
+
+    // Should contain user features
+    XCTAssertTrue(featureList!.contains("L/A"))
+    XCTAssertTrue(featureList!.contains("M/B"))
+  }
+
+  func testCreateMetricsWithVersionMismatch() {
+    // User provides features with wrong version - should only use CRT features
+    var customMetrics = IoTDeviceSDKMetrics(libraryName: "CustomSDK/Test")
+    customMetrics.metadata["IoTSDKMetricsVersion"] = "999"  // Wrong version
+    customMetrics.metadata["IoTSDKFeature"] = "L/A,M/B"  // Custom features
+
+    let options = MqttClientOptions(
+      hostName: "test.example.com",
+      port: 8883,
+      sessionBehavior: .clean,
+      metrics: customMetrics
+    )
+
+    let metrics = IoTSDKMetricsEncoder.createMetrics(from: options)
+
+    // Should NOT contain user features due to version mismatch
+    let featureList = metrics.metadata["IoTSDKFeature"]
+    XCTAssertNotNil(featureList)
+
+    // Should contain CRT features
+    XCTAssertTrue(featureList!.contains("F/5"))  // MQTT5
+
+    // Should NOT contain user features
+    XCTAssertFalse(featureList!.contains("L/A"))
+    XCTAssertFalse(featureList!.contains("M/B"))
+  }
+
+  func testCreateMetricsCRTVersionNotModifiable() {
+    // User tries to set CRTVersion - should be overwritten
+    var customMetrics = IoTDeviceSDKMetrics(libraryName: "CustomSDK/Test")
+    customMetrics.metadata["CRTVersion"] = "user-version"
+
+    let options = MqttClientOptions(
+      hostName: "test.example.com",
+      port: 8883,
+      metrics: customMetrics
+    )
+
+    let metrics = IoTSDKMetricsEncoder.createMetrics(from: options)
+
+    // CRTVersion should be the library's version, not user's
+    XCTAssertEqual(metrics.metadata["CRTVersion"], CommonRuntimeKit.CRTVersion)
+  }
+
+  func testCreateMetricsPreservesOtherUserMetadata() {
+    // User provides other metadata that should be preserved
+    var customMetrics = IoTDeviceSDKMetrics(libraryName: "CustomSDK/Test")
+    customMetrics.metadata["CustomKey1"] = "CustomValue1"
+    customMetrics.metadata["CustomKey2"] = "CustomValue2"
+
+    let options = MqttClientOptions(
+      hostName: "test.example.com",
+      port: 8883,
+      metrics: customMetrics
+    )
+
+    let metrics = IoTSDKMetricsEncoder.createMetrics(from: options)
+
+    // Custom metadata should be preserved
+    XCTAssertEqual(metrics.metadata["CustomKey1"], "CustomValue1")
+    XCTAssertEqual(metrics.metadata["CustomKey2"], "CustomValue2")
+  }
+
+}

--- a/Test/AwsCommonRuntimeKitTests/mqtt/IoTSDKMetricsTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/mqtt/IoTSDKMetricsTests.swift
@@ -83,7 +83,7 @@ class IoTSDKMetricsTests: XCBaseTestCase {
   func testCreateMetricsWithUserFeaturesMerged() {
     let customMetrics = IoTDeviceSDKMetrics(libraryName: "CustomSDK/Test")
     customMetrics.metadata["IoTSDKMetricsVersion"] = "1"
-    customMetrics.metadata["IoTSDKFeature"] = "(L/A,M/B)"  // Custom features with parentheses
+    customMetrics.metadata["IoTSDKFeature"] = "L/A,M/B"  // Custom features
 
     let options = MqttClientOptions(
       hostName: "test.example.com",

--- a/Test/AwsCommonRuntimeKitTests/mqtt/IoTSDKMetricsTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/mqtt/IoTSDKMetricsTests.swift
@@ -44,11 +44,11 @@ class IoTSDKMetricsTests: XCBaseTestCase {
     let encoded = IoTSDKMetricsEncoder.getEncodedFeatureList(from: options)
 
     // Verify each NON-DEFAULT feature is present with new ID/Value format
-    XCTAssertTrue(encoded.contains("A/C"))  // retry_jitter_mode = DECORRELATED (non-default)
-    XCTAssertTrue(encoded.contains("B/C"))  // session_behavior = REJOIN_ALWAYS (non-default)
-    XCTAssertTrue(encoded.contains("C/C"))  // offline_queue_behavior = FAIL_ALL_ON_DISCONNECT (non-default)
-    XCTAssertTrue(encoded.contains("D/B"))  // outbound_topic_alias_behavior = LRU (non-default)
-    XCTAssertTrue(encoded.contains("E/A"))  // inbound_topic_alias_behavior = ENABLED (non-default)
+    XCTAssertTrue(encoded.contains("A/C"))  // retry_jitter_mode = DECORRELATED
+    XCTAssertTrue(encoded.contains("B/C"))  // session_behavior = REJOIN_ALWAYS
+    XCTAssertTrue(encoded.contains("C/C"))  // offline_queue_behavior = FAIL_ALL_ON_DISCONNECT
+    XCTAssertTrue(encoded.contains("D/B"))  // outbound_topic_alias_behavior = LRU
+    XCTAssertTrue(encoded.contains("E/A"))  // inbound_topic_alias_behavior = ENABLED
     XCTAssertTrue(encoded.contains("F/5"))  // protocol_version = MQTT5
 
     // Verify the format is comma-separated

--- a/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
@@ -208,7 +208,7 @@ class Mqtt5ClientTests: XCBaseTestCase, @unchecked Sendable {
         onLifecycleEventConnectionSuccessFn: testContext.onLifecycleEventConnectionSuccess,
         onLifecycleEventConnectionFailureFn: testContext.onLifecycleEventConnectionFailure,
         onLifecycleEventDisconnectionFn: testContext.onLifecycleEventDisconnection,
-        enableMetrics: clientOptions.enableMetrics)
+        disableMetrics: clientOptions.disableMetrics)
     } else {
       let elg = try EventLoopGroup()
       let resolver = try HostResolver(
@@ -414,7 +414,7 @@ class Mqtt5ClientTests: XCBaseTestCase, @unchecked Sendable {
       hostName: inputHost,
       port: UInt32(inputPort)!,
       connectOptions: connectOptions,
-      enableMetrics: false)
+      disableMetrics: true)
 
     let testContext = MqttTestContext()
     let client = try createClient(clientOptions: clientOptions, testContext: testContext)
@@ -444,12 +444,12 @@ class Mqtt5ClientTests: XCBaseTestCase, @unchecked Sendable {
       username: inputUsername,
       password: inputPassword.data(using: .utf8))
 
-    // Metrics enabled
+    // Metrics enabled (disableMetrics: false)
     let clientOptions = MqttClientOptions(
       hostName: inputHost,
       port: UInt32(inputPort)!,
       connectOptions: connectOptions,
-      enableMetrics: true)
+      disableMetrics: false)
 
     let testContext: Mqtt5ClientTests.MqttTestContext = MqttTestContext()
     let client = try createClient(clientOptions: clientOptions, testContext: testContext)
@@ -712,7 +712,7 @@ class Mqtt5ClientTests: XCBaseTestCase, @unchecked Sendable {
       hostName: inputHost,
       port: UInt32(inputPort)!,
       connectOptions: connectOptions,
-      enableMetrics: false)
+      disableMetrics: true)
 
     let testContext = MqttTestContext()
     testContext.withWebsocketTransform(isSuccess: true)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The review will focus on high level API changes and structure. It include the following changes 
1. Add  `IoTDeviceSDKMetrics` structure. The struct will hold metrics information. 
`AwsIoTSDKMetrics` (private) -> `IoTDeviceSDKMetrics` (public). 
2. MqttClientOptions 
    - `enableMetrics` -> `disableMetrics` : change name convention to `disable` to focus on the "opt-out" pattern and reduce cognitive load.
    - Add metrics option, so user can now set their own metrics
3. Add IoTSDKMetricsEncoder (Internal struct) to help build the encoded metrics string  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
