### PR TITLE
workflow to set crt version string

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -3,6 +3,7 @@ name: Update Version on Release
 # This workflow automatically updates the CRTVersion in CommonRuntimeKit.swift when a new release is created.
 # It extracts the version from the tag (e.g., v0.61.0 -> 0.61.0), updates the source file,
 # and moves the tag to point to the new commit with the updated version.
+# The original release title and body are preserved when recreating the release.
 
 on:
   release:
@@ -30,10 +31,14 @@ jobs:
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION from tag: $TAG_NAME"
+          
+          # Store release info for later use
+          echo "Release title: ${{ github.event.release.name }}"
+          echo "Release is prerelease: ${{ github.event.release.prerelease }}"
 
       - name: Update CRTVersion in CommonRuntimeKit.swift
         run: |
-          VERSION="${{ steps.get_version.outputs.version }}"
+          VERSION="${{ steps.get_info.outputs.version }}"
           VERSION_FILE="Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift"
           
           # Update the CRTVersion in CommonRuntimeKit.swift
@@ -63,8 +68,12 @@ jobs:
             git diff
           fi
 
-      - name: Commit version update and move tag
+      - name: Commit version update, move tag, and recreate release
         if: steps.check_changes.outputs.has_changes == 'true'
+        env:
+          RELEASE_TITLE: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           VERSION="${{ steps.get_version.outputs.version }}"
           TAG_NAME="${{ steps.get_version.outputs.tag }}"
@@ -79,12 +88,40 @@ jobs:
           # Push the commit to main
           git push origin main
           
+          # Delete the old release (this also allows us to delete the tag)
+          echo "Deleting old release..."
+          gh release delete "$TAG_NAME" --yes
+          
           # Delete the old tag (both locally and remotely)
           git tag -d "$TAG_NAME"
           git push origin --delete "$TAG_NAME"
           
           # Create a new tag pointing to the new commit with the updated version
-          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+          # Use the release body as the tag message
+          if [ -n "$RELEASE_BODY" ]; then
+            git tag -a "$TAG_NAME" -m "$RELEASE_BODY"
+          else
+            git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+          fi
           git push origin "$TAG_NAME"
           
-          echo "✅ CRTVersion updated to $VERSION and tag $TAG_NAME moved to new commit"
+          # Recreate the release with the original title and body
+          echo "Recreating release with original title and body..."
+          PRERELEASE_FLAG=""
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          
+          # Use the original title, or fall back to tag name if empty
+          if [ -n "$RELEASE_TITLE" ]; then
+            TITLE="$RELEASE_TITLE"
+          else
+            TITLE="$TAG_NAME"
+          fi
+          
+          gh release create "$TAG_NAME" \
+            --title "$TITLE" \
+            --notes "$RELEASE_BODY" \
+            $PRERELEASE_FLAG
+          
+          echo "✅ CRTVersion updated to $VERSION, tag $TAG_NAME moved to new commit, and release recreated"

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,90 @@
+name: Update Version on Release
+
+# This workflow automatically updates the CRTVersion in CommonRuntimeKit.swift when a new release is created.
+# It extracts the version from the tag (e.g., v0.61.0 -> 0.61.0), updates the source file,
+# and moves the tag to point to the new commit with the updated version.
+
+on:
+  release:
+    types: [published]  # Triggers when a release is published via GitHub UI
+
+permissions:
+  contents: write  # Required to push commits and tags
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main  # Checkout main branch to apply the version update
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          # Remove the 'v' prefix to get the version
+          VERSION=${TAG_NAME#v}
+          echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION from tag: $TAG_NAME"
+
+      - name: Update CRTVersion in CommonRuntimeKit.swift
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          VERSION_FILE="Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift"
+          
+          # Update the CRTVersion in CommonRuntimeKit.swift
+          sed -i "s/public static let CRTVersion = \".*\"/public static let CRTVersion = \"$VERSION\"/" "$VERSION_FILE"
+          
+          # Verify the update
+          echo "Updated $VERSION_FILE:"
+          cat "$VERSION_FILE"
+          
+          # Check if the version was actually updated
+          if grep -q "public static let CRTVersion = \"$VERSION\"" "$VERSION_FILE"; then
+            echo "✅ CRTVersion successfully updated to $VERSION"
+          else
+            echo "❌ Failed to update CRTVersion"
+            exit 1
+          fi
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes detected (version may already be up to date)"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected"
+            git diff
+          fi
+
+      - name: Commit version update and move tag
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          TAG_NAME="${{ steps.get_version.outputs.tag }}"
+          
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          
+          # Commit the version update
+          git add Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+          git commit -m "chore: update CRTVersion to $VERSION"
+          
+          # Push the commit to main
+          git push origin main
+          
+          # Delete the old tag (both locally and remotely)
+          git tag -d "$TAG_NAME"
+          git push origin --delete "$TAG_NAME"
+          
+          # Create a new tag pointing to the new commit with the updated version
+          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+          git push origin "$TAG_NAME"
+          
+          echo "✅ CRTVersion updated to $VERSION and tag $TAG_NAME moved to new commit"

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Update CRTVersion in CommonRuntimeKit.swift
         run: |
-          VERSION="${{ steps.get_info.outputs.version }}"
+          VERSION="${{ steps.get_version.outputs.version }}"
           VERSION_FILE="Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift"
           
           # Update the CRTVersion in CommonRuntimeKit.swift

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -9,6 +9,9 @@ on:
   release:
     types: [published]  # Triggers when a release is published via GitHub UI
 
+permissions:
+  contents: read  # Set minimal permissions for GITHUB_TOKEN (BOT_PAT handles write operations)
+
 env:
   GH_TOKEN: ${{ secrets.BOT_PAT }}
 

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -9,8 +9,8 @@ on:
   release:
     types: [published]  # Triggers when a release is published via GitHub UI
 
-permissions:
-  contents: write  # Required to push commits and tags
+env:
+  GH_TOKEN: ${{ secrets.BOT_PAT }}
 
 jobs:
   update-version:
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.BOT_PAT }}  # Use BOT_PAT for push permissions
           ref: main  # Checkout main branch to apply the version update
           fetch-depth: 0
 

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -78,8 +78,8 @@ jobs:
           VERSION="${{ steps.get_version.outputs.version }}"
           TAG_NAME="${{ steps.get_version.outputs.tag }}"
           
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "aws-sdk-common-runtime@amazon.com"
+          git config --local user.name "GitHub Actions"
           
           # Commit the version update
           git add Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -7,6 +7,9 @@ import LibNative
 /// `CommonRuntimeKit.initialize` must be called before using any other functionality.
 public struct CommonRuntimeKit {
 
+  /// The current version of the AWS Common Runtime Kit.
+  public static let CRTVersion = "0.0.0"
+
   /// Initializes the library.
   /// Must be called before using any other functionality.
   public static func initialize() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added a workflow to setup CRT version string. Whenever the team cut it will automatically grab the release tag and update the `CRTVersion` version string.


HOW IT WORKS:
   1. Triggers when a release is published via the GitHub UI
   2. Extracts the semantic version from the tag (e.g., v0.61.0 -> 0.61.0)
   3. Updates CommonRuntimeKit.swift with the new version
   4. Commits the change to main branch
   5. Moves the release tag to point to the new commit (with updated version) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
