### PR TITLE
Cbor decoder resource limits

### DIFF
--- a/Source/AwsCommonRuntimeKit/crt/CBOR.swift
+++ b/Source/AwsCommonRuntimeKit/crt/CBOR.swift
@@ -186,7 +186,8 @@ public class CBORDecoder {
   /// You must call `hasNext()` before calling this function.
   public func popNext() throws -> CBORType {
     guard currentDepth < CBORDecoder.maxDepth else {
-      throw CommonRunTimeError.crtError(CRTError(code: AWS_ERROR_CBOR_RESOURCE_LIMIT_EXCEEDED.rawValue))
+      throw CommonRunTimeError.crtError(
+        CRTError(code: AWS_ERROR_CBOR_RESOURCE_LIMIT_EXCEEDED.rawValue))
     }
     currentDepth += 1
     defer { currentDepth -= 1 }

--- a/Source/AwsCommonRuntimeKit/crt/CBOR.swift
+++ b/Source/AwsCommonRuntimeKit/crt/CBOR.swift
@@ -158,6 +158,11 @@ public class CBORDecoder {
   /// for `indef_break` to detect the end of an indefinite collection.
   let rollupCollections: Bool
 
+  /// Maximum nesting depth for recursive decoding to prevent stack exhaustion
+  private static let maxDepth = 128
+  /// Current nesting depth
+  private var currentDepth = 0
+
   public init(data: [UInt8], rollupCollections: Bool = true) throws {
     self.data = data
     let count = self.data.count
@@ -180,6 +185,12 @@ public class CBORDecoder {
   /// Decodes and returns the next value. If there is no value, this function will throw an error.
   /// You must call `hasNext()` before calling this function.
   public func popNext() throws -> CBORType {
+    guard currentDepth < CBORDecoder.maxDepth else {
+      throw CommonRunTimeError.crtError(CRTError(code: AWS_ERROR_CBOR_RESOURCE_LIMIT_EXCEEDED.rawValue))
+    }
+    currentDepth += 1
+    defer { currentDepth -= 1 }
+
     let cbor_type = try peekAtNextElement()
 
     switch cbor_type {

--- a/Test/AwsCommonRuntimeKitTests/crt/CBOR.swift
+++ b/Test/AwsCommonRuntimeKitTests/crt/CBOR.swift
@@ -274,7 +274,7 @@ class CBORTests: XCBaseTestCase {
     // 129 nested arrays of length 1: [[[...[1]...]]]
     // Each 0x81 = definite array of 1 element
     var data: [UInt8] = Array(repeating: 0x81, count: 129)
-    data.append(0x01) // innermost value: uint 1
+    data.append(0x01)  // innermost value: uint 1
 
     let decoder = try CBORDecoder(data: data)
     XCTAssertThrowsError(try decoder.popNext()) { error in

--- a/Test/AwsCommonRuntimeKitTests/crt/CBOR.swift
+++ b/Test/AwsCommonRuntimeKitTests/crt/CBOR.swift
@@ -269,4 +269,17 @@ class CBORTests: XCBaseTestCase {
     let next = try decoder.popNext()
     XCTAssertEqual(next, element)
   }
+
+  func test_depthLimit_rejectsDeepNesting() throws {
+    // 129 nested arrays of length 1: [[[...[1]...]]]
+    // Each 0x81 = definite array of 1 element
+    var data: [UInt8] = Array(repeating: 0x81, count: 129)
+    data.append(0x01) // innermost value: uint 1
+
+    let decoder = try CBORDecoder(data: data)
+    XCTAssertThrowsError(try decoder.popNext()) { error in
+      // Should fail due to depth limit exceeded
+      XCTAssertTrue(error is CommonRunTimeError)
+    }
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- pick up change from https://github.com/awslabs/aws-c-common/pull/1247
- Apply the same limitation of the recursive callstack in the binding. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
