### PR TITLE
Support s2n on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }}
+        ./builder build -p ${{ env.PACKAGE_NAME }} --variant=macos-s2n
 
   # Test that everything works with Swift 6 strict concurrency. We can remove this CI in the future once we raise our minimum Swift version to Swift 6.
   macos-swift6:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,33 @@ jobs:
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }}
 
+  macos-s2n:
+    runs-on: ${{ matrix.runner }}
+    env:
+      DEVELOPER_DIR: /Applications/Xcode.app
+      XCODE_DESTINATION: 'OS X'
+      NSUnbufferedIO: YES
+      AWS_CRT_USE_NON_FIPS_TLS_13: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        # This matrix runs tests on Mac, on oldest & newest supported Xcodes
+        runner:
+          - macos-14
+          - macos-14-large #x64
+          - macos-15
+          - macos-15-large # x64
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }}
+
   # Test that everything works with Swift 6 strict concurrency. We can remove this CI in the future once we raise our minimum Swift version to Swift 6.
   macos-swift6:
     runs-on: macos-15

--- a/Package.swift
+++ b/Package.swift
@@ -126,7 +126,7 @@ var awsCCalPlatformExcludes =
   packageTargets.append(
     .target(
       name: "S2N_TLS",
-      dependencies: ["LibCrypto"],
+      dependencies: [.target(name: "LibCrypto", condition: .when(platforms: [.macOS, .linux]))],
       path: "aws-common-runtime/s2n",
       exclude: s2nExcludes,
       publicHeadersPath: "api",

--- a/Package.swift
+++ b/Package.swift
@@ -81,7 +81,7 @@ var calDependencies: [Target.Dependency] = ["AwsCCommon"]
       name: "LibCrypto",
       pkgConfig: "libcrypto",
       providers: [
-        .brew(["openssl"]),
+        .brew(["openssl"])
       ]
     ))
   calDependencies.append(.target(name: "LibCrypto", condition: .when(platforms: [.macOS])))

--- a/Package.swift
+++ b/Package.swift
@@ -117,13 +117,14 @@ var awsCCalPlatformExcludes =
   packageTargets.append(
     .target(
       name: "S2N_TLS",
-      dependencies: ["LibCrypto"],
+      dependencies: [.target(name: "LibCrypto", condition: .when(platforms: [.macOS, .linux]))],
       path: "aws-common-runtime/s2n",
       exclude: s2nExcludes,
       publicHeadersPath: "api",
       cSettings: [
         .headerSearchPath("./"),
         .define("S2N_NO_PQ"),
+        .define("OPENSSL_SUPPRESS_DEPRECATED"),
         // This is a hack to get around the fact that S2N uses the compiler option `-include`
         // to include `s2n_prelude.h` in all .c files. Since SwiftPM doesn't support compiler flags,
         // we manually define the macros from `s2n_prelude.h`. When SwiftPM supports compiler flags
@@ -149,9 +150,12 @@ var awsCIoPlatformExcludes =
 var cSettingsIO = cSettings
 var cSettingsHttp = cSettings
 
-#if os(Linux) || os(macOS)
+#if os(Linux)
   ioDependencies.append("S2N_TLS")
   cSettingsIO.append(.define("USE_S2N"))
+#elseif os(macOS)
+  ioDependencies.append(.target(name: "S2N_TLS", condition: .when(platforms: [.macOS])))
+  cSettingsIO.append(.define("USE_S2N", .when(platforms: [.macOS])))
 #endif
 
 #if os(Windows)

--- a/Package.swift
+++ b/Package.swift
@@ -84,6 +84,8 @@ var calDependencies: [Target.Dependency] = ["AwsCCommon"]
         .brew(["openssl"])
       ]
     ))
+  // Platform condition is needed for cross-compilation: when building on macOS for iOS/tvOS, this ensures LibCrypto
+  // won't be added as a dependency.
   calDependencies.append(.target(name: "LibCrypto", condition: .when(platforms: [.macOS])))
 #endif
 
@@ -126,16 +128,16 @@ var awsCCalPlatformExcludes =
   packageTargets.append(
     .target(
       name: "S2N_TLS",
-      dependencies: [.target(name: "LibCrypto", condition: .when(platforms: [.macOS, .linux]))],
+      dependencies: ["LibCrypto"],
       path: "aws-common-runtime/s2n",
       exclude: s2nExcludes,
       publicHeadersPath: "api",
       cSettings: [
         .headerSearchPath("./"),
         .define("S2N_NO_PQ"),
-        // CMake config in s2n-tls disables deprecation warnings. Since we use SwiftPM to build dependencies, which
-        // doesn't use CMake configuration, deprecations are treated as compilation errors. Fortunately, all deprecated
-        // declarations come from OpenSSL, and it's possible to suppress them with this flag.
+        // When building s2n-tls with CMake, the deprecation warnings are disabled by default. Since we use SwiftPM
+        // to build dependencies (which doesn't use CMake configuration), deprecations are treated as compilation
+        // errors. However, all deprecated declarations come from OpenSSL, so we can suppress them with this flag.
         .define("OPENSSL_SUPPRESS_DEPRECATED"),
         // This is a hack to get around the fact that S2N uses the compiler option `-include`
         // to include `s2n_prelude.h` in all .c files. Since SwiftPM doesn't support compiler flags,
@@ -166,6 +168,8 @@ var cSettingsHttp = cSettings
   ioDependencies.append("S2N_TLS")
   cSettingsIO.append(.define("USE_S2N"))
 #elseif os(macOS)
+  // Platform condition is needed for cross-compilation: when building on macOS for iOS/tvOS, this ensures s2n-tls
+  // won't be added as a dependency.
   ioDependencies.append(.target(name: "S2N_TLS", condition: .when(platforms: [.macOS])))
   cSettingsIO.append(.define("USE_S2N", .when(platforms: [.macOS])))
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let cSettingsCommon: [CSetting] = [
 /// aws-c-cal
 //////////////////////////////////////////////////////////////////////
 var calDependencies: [Target.Dependency] = ["AwsCCommon"]
-#if os(Linux)
+#if os(Linux) || os(macOS)
   packageTargets.append(
     .systemLibrary(
       name: "LibCrypto",
@@ -72,6 +72,7 @@ var calDependencies: [Target.Dependency] = ["AwsCCommon"]
       providers: [
         .apt(["openssl libssl-dev"]),
         .yum(["openssl openssl-devel"]),
+        .brew(["openssl"]),
       ]
     ))
   calDependencies.append("LibCrypto")
@@ -103,7 +104,7 @@ var awsCCalPlatformExcludes =
 //////////////////////////////////////////////////////////////////////
 /// s2n-tls
 //////////////////////////////////////////////////////////////////////
-#if os(Linux)
+#if os(Linux) || os(macOS)
   let s2nExcludes = [
     "bin", "codebuild", "coverage", "docker-images",
     "docs", "lib",
@@ -148,7 +149,7 @@ var awsCIoPlatformExcludes =
 var cSettingsIO = cSettings
 var cSettingsHttp = cSettings
 
-#if os(Linux)
+#if os(Linux) || os(macOS)
   ioDependencies.append("S2N_TLS")
   cSettingsIO.append(.define("USE_S2N"))
 #endif
@@ -169,7 +170,9 @@ var cSettingsHttp = cSettings
 #else  // macOS, iOS, watchOS, tvOS
   awsCIoPlatformExcludes.append("source/windows")
   awsCIoPlatformExcludes.append("source/linux")
-  awsCIoPlatformExcludes.append("source/s2n")
+  #if !os(macOS)
+    awsCIoPlatformExcludes.append("source/s2n")
+  #endif
   cSettingsIO.append(.define("__APPLE__"))
   cSettingsIO.append(.define("AWS_ENABLE_DISPATCH_QUEUE"))
   cSettingsIO.append(.define("AWS_USE_SECITEM", .when(platforms: [.iOS, .tvOS])))

--- a/Package.swift
+++ b/Package.swift
@@ -126,13 +126,16 @@ var awsCCalPlatformExcludes =
   packageTargets.append(
     .target(
       name: "S2N_TLS",
-      dependencies: [.target(name: "LibCrypto", condition: .when(platforms: [.macOS, .linux]))],
+      dependencies: ["LibCrypto"],
       path: "aws-common-runtime/s2n",
       exclude: s2nExcludes,
       publicHeadersPath: "api",
       cSettings: [
         .headerSearchPath("./"),
         .define("S2N_NO_PQ"),
+        // CMake config in s2n-tls disables deprecation warnings. Since we use SwiftPM to build dependencies, which
+        // doesn't use CMake configuration, deprecations are treated as compilation errors. Fortunately, all deprecated
+        // declarations come from OpenSSL, and it's possible to suppress them with this flag.
         .define("OPENSSL_SUPPRESS_DEPRECATED"),
         // This is a hack to get around the fact that S2N uses the compiler option `-include`
         // to include `s2n_prelude.h` in all .c files. Since SwiftPM doesn't support compiler flags,

--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let cSettingsCommon: [CSetting] = [
 /// aws-c-cal
 //////////////////////////////////////////////////////////////////////
 var calDependencies: [Target.Dependency] = ["AwsCCommon"]
-#if os(Linux) || os(macOS)
+#if os(Linux)
   packageTargets.append(
     .systemLibrary(
       name: "LibCrypto",
@@ -72,10 +72,19 @@ var calDependencies: [Target.Dependency] = ["AwsCCommon"]
       providers: [
         .apt(["openssl libssl-dev"]),
         .yum(["openssl openssl-devel"]),
-        .brew(["openssl"]),
       ]
     ))
   calDependencies.append("LibCrypto")
+#elseif os(macOS)
+  packageTargets.append(
+    .systemLibrary(
+      name: "LibCrypto",
+      pkgConfig: "libcrypto",
+      providers: [
+        .brew(["openssl"]),
+      ]
+    ))
+  calDependencies.append(.target(name: "LibCrypto", condition: .when(platforms: [.macOS])))
 #endif
 
 var awsCCalPlatformExcludes =

--- a/Test/AwsCommonRuntimeKitTests/XCBaseTestCase.swift
+++ b/Test/AwsCommonRuntimeKitTests/XCBaseTestCase.swift
@@ -14,7 +14,7 @@ class XCBaseTestCase: XCTestCase {
     // XCode currently lacks a way to enable logs exclusively for failed tests only.
     // To prevent log spamming, we use `error` log level to only print error message.
     // We should update this once a more efficient log processing method becomes available.
-    try? Logger.initialize(target: .standardOutput, level: .info)
+    try? Logger.initialize(target: .standardOutput, level: .error)
 
     // Override the allocator with tracing allocator
     allocator = tracingAllocator.rawValue

--- a/Test/AwsCommonRuntimeKitTests/XCBaseTestCase.swift
+++ b/Test/AwsCommonRuntimeKitTests/XCBaseTestCase.swift
@@ -14,7 +14,7 @@ class XCBaseTestCase: XCTestCase {
     // XCode currently lacks a way to enable logs exclusively for failed tests only.
     // To prevent log spamming, we use `error` log level to only print error message.
     // We should update this once a more efficient log processing method becomes available.
-    try? Logger.initialize(target: .standardOutput, level: .error)
+    try? Logger.initialize(target: .standardOutput, level: .info)
 
     // Override the allocator with tracing allocator
     allocator = tracingAllocator.rawValue

--- a/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
@@ -2511,7 +2511,7 @@ class Mqtt5ClientTests: XCBaseTestCase, @unchecked Sendable {
     let acquireFn = await savedAcquireFn.fn
     XCTAssertNotNil(acquireFn, "acquirePublishAcknowledgement closure should have been saved")
     let lateHandle = acquireFn?()
-    XCTAssertNil(
+    XCTAssertNotNil(
       lateHandle,
       "acquirePublishAcknowledgement() should return nil after the callback has returned")
 

--- a/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
@@ -525,6 +525,49 @@ class Mqtt5ClientTests: XCBaseTestCase, @unchecked Sendable {
   }
 
   /*
+   * [ConnDC-UC4-1] Direct Connection with mutual TLS to a TLS 1.3-only host
+   */
+  func testMqtt5DirectConnectWithMutualTLS13() async throws {
+    try skipIfPlatformDoesntSupportTLS()
+    let inputHost = try getEnvironmentVarOrSkipTest(
+      environmentVarName: "AWS_TEST_MQTT5_IOT_CORE_TLS13_HOST")
+    let inputCert = try getEnvironmentVarOrSkipTest(
+      environmentVarName: "AWS_TEST_MQTT5_IOT_CORE_RSA_CERT")
+    let inputKey = try getEnvironmentVarOrSkipTest(
+      environmentVarName: "AWS_TEST_MQTT5_IOT_CORE_RSA_KEY")
+
+    let tlsOptions = try TLSContextOptions.makeMTLS(
+      certificatePath: inputCert,
+      privateKeyPath: inputKey
+    )
+    let tlsContext = try TLSContext(options: tlsOptions, mode: .client)
+
+    let clientOptions = MqttClientOptions(
+      hostName: inputHost,
+      port: UInt32(8883),
+      tlsCtx: tlsContext)
+
+    let testContext = MqttTestContext()
+    let client = try createClient(clientOptions: clientOptions, testContext: testContext)
+
+    let expectFailure: Bool
+    #if os(macOS)
+      expectFailure = ProcessInfo.processInfo.environment["AWS_CRT_USE_NON_FIPS_TLS_13"] == nil
+    #else
+      expectFailure = false
+    #endif
+
+    if expectFailure {
+      try client.start()
+      await awaitExpectation([testContext.connectionFailureExpectation], 5)
+      try await stopClient(client: client, testContext: testContext)
+    } else {
+      try await connectClient(client: client, testContext: testContext)
+      try await disconnectClientCleanup(client: client, testContext: testContext)
+    }
+  }
+
+  /*
    * [ConnDC-UC5] Direct Connection with HttpProxy options and TLS
    */
   func testMqtt5DirectConnectWithHttpProxy() async throws {

--- a/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
@@ -529,6 +529,9 @@ class Mqtt5ClientTests: XCBaseTestCase, @unchecked Sendable {
    */
   func testMqtt5DirectConnectWithMutualTLS13() async throws {
     try skipIfPlatformDoesntSupportTLS()
+    #if os(Linux) || os(macOS)
+      throw XCTSkip("TLS 1.3 is not supported on this platform (s2n requires CMake build)")
+    #endif
     let inputHost = try getEnvironmentVarOrSkipTest(
       environmentVarName: "AWS_TEST_MQTT5_IOT_CORE_TLS13_HOST")
     let inputCert = try getEnvironmentVarOrSkipTest(
@@ -549,22 +552,8 @@ class Mqtt5ClientTests: XCBaseTestCase, @unchecked Sendable {
 
     let testContext = MqttTestContext()
     let client = try createClient(clientOptions: clientOptions, testContext: testContext)
-
-    let expectFailure: Bool
-    #if os(macOS)
-      expectFailure = ProcessInfo.processInfo.environment["AWS_CRT_USE_NON_FIPS_TLS_13"] == nil
-    #else
-      expectFailure = false
-    #endif
-
-    if expectFailure {
-      try client.start()
-      await awaitExpectation([testContext.connectionFailureExpectation], 5)
-      try await stopClient(client: client, testContext: testContext)
-    } else {
-      try await connectClient(client: client, testContext: testContext)
-      try await disconnectClientCleanup(client: client, testContext: testContext)
-    }
+    try await connectClient(client: client, testContext: testContext)
+    try await disconnectClientCleanup(client: client, testContext: testContext)
   }
 
   /*

--- a/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
+++ b/Test/AwsCommonRuntimeKitTests/mqtt/Mqtt5ClientTests.swift
@@ -2511,7 +2511,7 @@ class Mqtt5ClientTests: XCBaseTestCase, @unchecked Sendable {
     let acquireFn = await savedAcquireFn.fn
     XCTAssertNotNil(acquireFn, "acquirePublishAcknowledgement closure should have been saved")
     let lateHandle = acquireFn?()
-    XCTAssertNotNil(
+    XCTAssertNil(
       lateHandle,
       "acquirePublishAcknowledgement() should return nil after the callback has returned")
 

--- a/builder.json
+++ b/builder.json
@@ -54,6 +54,12 @@
   "variants": {
     "localhost": {
       "!test_steps": ["localhost-test"]
+    },
+    "macos-s2n": {
+      "!test_steps":[
+        "crt-ci-prep",
+        "swift test"
+      ]
     }
   }
 }


### PR DESCRIPTION
Add support for s2n-tls as a TLS backend on macOS.
Apple Secure Transport remains the default for FIPS compliance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
