### PR TITLE
Make CRT initialize thread safe

### DIFF
--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -19,7 +19,7 @@ public struct CommonRuntimeKit {
   // Tracks whether the C libraries have been initialized, so a second call to
   // `initialize()` is a no-op instead of re-running aws_*_library_init. Only
   // read/written while holding `lock`.
-  private static var isInitialized = false
+  private nonisolated(unsafe) static var isInitialized = false
 
   /// Initializes the library.
   /// Must be called before using any other functionality.

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -19,7 +19,7 @@ public struct CommonRuntimeKit {
   // Tracks whether the C libraries have been initialized, so a second call to
   // `initialize()` is a no-op instead of re-running aws_*_library_init. Only
   // read/written while holding `lock`.
-  private nonisolated(unsafe) static var isInitialized = false
+  private static nonisolated(unsafe) var isInitialized = false
 
   /// Initializes the library.
   /// Must be called before using any other functionality.

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -19,7 +19,7 @@ public struct CommonRuntimeKit {
   // Tracks whether the C libraries have been initialized, so a second call to
   // `initialize()` is a no-op instead of re-running aws_*_library_init. Only
   // read/written while holding `lock`.
-  private static nonisolated(unsafe) var isInitialized = false
+  private nonisolated(unsafe) var isInitialized = false
 
   /// Initializes the library.
   /// Must be called before using any other functionality.

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -2,6 +2,7 @@ import AwsCAuth
 import AwsCEventStream
 import AwsCMqtt
 import LibNative
+import Foundation
 
 /// Initializes the library.
 /// `CommonRuntimeKit.initialize` must be called before using any other functionality.
@@ -9,10 +10,14 @@ public struct CommonRuntimeKit {
 
   /// The current version of the AWS Common Runtime Kit.
   public static let CRTVersion = "0.0.0"
+  private static let lock = NSLock()
 
   /// Initializes the library.
   /// Must be called before using any other functionality.
   public static func initialize() {
+    lock.lock()
+    defer { lock.unlock() }
+
     aws_auth_library_init(allocator.rawValue)
     aws_event_stream_library_init(allocator.rawValue)
     aws_mqtt_library_init(allocator.rawValue)

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -16,12 +16,18 @@ public struct CommonRuntimeKit {
   // which can race that flag and return before setup (e.g. TLS trust store) completes.
   // This lock serializes calls; see https://github.com/awslabs/aws-crt-swift/issues/352.
   private static let lock = NSLock()
+  // Tracks whether the C libraries have been initialized, so a second call to
+  // `initialize()` is a no-op instead of re-running aws_*_library_init. Only
+  // read/written while holding `lock`.
+  private static var isInitialized = false
 
   /// Initializes the library.
   /// Must be called before using any other functionality.
   public static func initialize() {
     lock.lock()
     defer { lock.unlock() }
+    guard !isInitialized else { return }
+    isInitialized = true
 
     aws_auth_library_init(allocator.rawValue)
     aws_event_stream_library_init(allocator.rawValue)
@@ -37,6 +43,11 @@ public struct CommonRuntimeKit {
    * Warning: It will hang if you are still holding references to any CRT objects such as HostResolver.
    */
   public static nonisolated func cleanUp() {
+    lock.lock()
+    defer { lock.unlock() }
+    guard isInitialized else { return }
+    isInitialized = false
+
     withUnsafePointer(to: s_crt_swift_error_list) { ptr in
       aws_unregister_error_info(ptr)
     }

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -10,6 +10,11 @@ public struct CommonRuntimeKit {
 
   /// The current version of the AWS Common Runtime Kit.
   public static let CRTVersion = "0.0.0"
+  // The underlying aws_*_library_init C calls use unguarded check-then-act flags
+  // (e.g. aws-c-io's s_io_library_initialized), assuming a single-threaded, call-once
+  // caller. Swift exposes `initialize()` as public API callable from multiple threads,
+  // which can race that flag and return before setup (e.g. TLS trust store) completes.
+  // This lock serializes calls; see https://github.com/awslabs/aws-crt-swift/issues/352.
   private static let lock = NSLock()
 
   /// Initializes the library.

--- a/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
+++ b/Source/AwsCommonRuntimeKit/CommonRuntimeKit.swift
@@ -19,7 +19,13 @@ public struct CommonRuntimeKit {
   // Tracks whether the C libraries have been initialized, so a second call to
   // `initialize()` is a no-op instead of re-running aws_*_library_init. Only
   // read/written while holding `lock`.
-  private nonisolated(unsafe) var isInitialized = false
+  // Swift 6 flags this as unsafe global mutable state; disable the check since access
+  // is always serialized by `lock`. Remove the #if once our minimum Swift version reaches 5.10.
+  #if swift(>=5.10)
+    private static nonisolated(unsafe) var isInitialized = false
+  #else
+    private static var isInitialized = false
+  #endif
 
   /// Initializes the library.
   /// Must be called before using any other functionality.


### PR DESCRIPTION
*Issue #, if available:*
#352 

*Description of changes:*
https://github.com/awslabs/aws-sdk-swift/issues/1984 & https://github.com/awslabs/aws-sdk-swift/issues/2138 talk about an issue that was filed with us but could not be reliably reproduced.

Creating a test that would reliably force a crash seems hard as this is a race, however running initialize from multiple threads and enabling ThreadSanitizer while testing allows us to see the race condition warning even if the test does not fail. Not adding the test since it might not be a necessary CI improvement. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
